### PR TITLE
fix(hygiene): skip TruffleHog secret scan on push-to-main (was comparing same-SHA ranges)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,15 @@ jobs:
         # pnpm.overrides (kept separate from scanner waivers).
         run: osv-scanner --config=.osv-scanner.toml --lockfile=pnpm-lock.yaml
       - name: Secret scanning
+        # Skipped on push events: TruffleHog's diff-mode fails when
+        # base + head resolve to the same commit, which is always the
+        # case on push-to-main (base = main = HEAD). PR events retain
+        # full scan coverage — that is the gate that actually blocks
+        # new secrets from landing. osv-scanner above still runs on
+        # push so fresh dependency advisories are caught on main.
+        # Local gitleaks via lefthook pre-commit remains the
+        # developer-side gate.
+        if: github.event_name == 'pull_request'
         uses: trufflesecurity/trufflehog@580628bb9d5455140899afe2cb981ff5640bf399 # main as of remediation date
         with:
           path: ./


### PR DESCRIPTION
## Framing

Fourth latent red CI gate surfaced after PRs #7 and #11 closed the three louder failures (OpenAPI validation, SBOM generation, OSV-Scanner action config). TruffleHog's push-event configuration has been broken since the action was added; it was masked by the three other failures. After #11 merged green, the main-branch push-event CI run immediately surfaced this as the sole remaining red job.

## Root cause

```yaml
- name: Secret scanning
  uses: trufflesecurity/trufflehog@…
  with:
    base: ${{ github.event.repository.default_branch }}   # → "main"
    head: HEAD
```

On `push` to `main`, the action resolves `BASE=main` and `HEAD=HEAD`, which point to the same commit (the push just updated main). The action's own guard then fails:

```
##[error]BASE and HEAD commits are the same. TruffleHog won't scan anything.
##[error]Process completed with exit code 1.
```

On `pull_request` events the same config works correctly because `base=main` resolves to main's tip while `HEAD` is the PR's tip — two different commits.

## Fix

Step-level `if: github.event_name == 'pull_request'` guard on the TruffleHog step only.

**Scope choice:** the Security-scan job also contains `osv-scanner`, which MUST keep running on push-to-main so fresh dependency advisories are caught on main even between PR events. A job-level guard would have disabled osv-scanner too, which is incorrect. Step-level is the narrower, clearer scope — documented in the commit body.

PR events retain full TruffleHog scan coverage. Local secret scanning via `lefthook` pre-commit `gitleaks` remains the developer-side gate.

## Post-M3.0 hygiene sequence

This is the third (and final) hygiene PR in the post-M3.0 sequence:

| PR  | Scope                                                                              |
| --- | ---------------------------------------------------------------------------------- |
| #7  | Restore green CI baseline (Prettier sweep + clamscan types + test eslint config)   |
| #11 | Repair three pre-M3.0 red CI gates (OpenAPI, OSV-Scanner, SBOM) + two CVE fixes    |
| #14 | Fix fourth latent red gate (TruffleHog push-event config) — this PR                |

After this merges green on push-to-main, the post-M3.0 CI baseline is genuinely established. The M3.A0 dormant-gate inventory task is exactly the class of systematic scan that would have caught all four latent issues up front — this PR's discovery validates that task's necessity.

## Test plan

- [x] Local format:check passes — workflow file edit only
- [ ] CI runs on this PR (pull_request event): TruffleHog step executes and passes (no secrets staged)
- [ ] After merge: CI runs on push-to-main: TruffleHog step shows SKIPPED, not FAILED; rest of Security-scan (osv-scanner) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)