### PR TITLE
fix(hygiene): add CODEOWNERS file (M3.0 T23 closure)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# CODEOWNERS — review required for changes to owned paths.
+# Syntax: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything.
+*                                @ib823
+
+# Security-critical paths — second reviewer strongly recommended
+# when M3 execution starts (per _plan/M3_EXECUTION_PLAN.md §10).
+# Until a second reviewer is named, self-review with explicit
+# CODEOWNERS re-request serves as the compensating control.
+/packages/crypto/                @ib823
+/packages/db/prisma/             @ib823
+/apps/control-plane/src/modules/auth/   @ib823
+/apps/control-plane/src/common/guards/  @ib823
+/infra/                          @ib823
+/.github/workflows/              @ib823
+
+# Planning + governance artefacts — user-level review
+/_plan/                          @ib823
+/_audit/                         @ib823
+/docs/adr/                       @ib823
+/PLANS.md                        @ib823
+/CLAUDE.md                       @ib823


### PR DESCRIPTION
## Summary

M3.0 plan T23 called for CODEOWNERS; the M3.0 handoff note did not list it as closed. The `verify-m3-0-findings.mjs` script surfaced the gap on first run (commit e0635db).

Scope strictly limited to `.github/CODEOWNERS` creation. Branch protection settings (the other half of T23) require GitHub UI configuration — follow-up docs/issue tracked separately.

## Content

- Default owner for all paths: `@ib823`
- Security-critical paths annotated (`packages/crypto`, `packages/db/prisma`, `control-plane/modules/auth`, `control-plane/common/guards`, `infra`, `.github/workflows`)
- Planning/governance paths annotated (`_plan`, `_audit`, `docs/adr`, `PLANS.md`, `CLAUDE.md`)
- Second-reviewer note deferred to M3 execution (currently self-review-with-explicit-re-request is the compensating control)

## Test plan

- [x] Local `pnpm run typecheck | lint | format:check | build | test:unit` — all green (`.github/` addition has no runtime impact)
- [ ] CI on this PR — all 8 gates green
- [ ] After merge, re-run `node _plan/scripts/verify-m3-0-findings.mjs` on main: CODEOWNERS check flips OK, remaining 6 FAILs unchanged (they are deferrals/new debt, not regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)