### PR TITLE
feat(m3.a1 pt1): database tenant isolation — RLS + role separation (PRIOR-R2-001 pt1)

### DIFF
--- a/_plan/M3_A1_EXECUTION_PROMPT.md
+++ b/_plan/M3_A1_EXECUTION_PROMPT.md
@@ -1,0 +1,303 @@
+# M3.A1 Execution Prompt — Database tenant isolation (RLS)
+
+**Status:** Canonical execution spec for M3.A1
+**Plan reference:** `_plan/M3_EXECUTION_PLAN.md` §5 M3.A1-T01 through M3.A1-T06
+**Created:** 2026-04-18 (initial session)
+**Amended:** 2026-04-19 (committed to `_plan/` after the first session surfaced that the prompt had been chat-only; see §0)
+
+## 0. Why this file exists
+
+M3.A1's first session ran successfully and landed T01 as commit `b608637`. On session resume, Claude Code stop-and-reported that `_plan/M3_A1_EXECUTION_PROMPT.md` was referenced as authoritative but didn't exist in the repo. This file is the committed version of what had previously lived only in chat — closing that gap so the spec is durable across sessions, bisectable, and readable six months from now.
+
+The execution content below is identical to the first session's spec. Only the scaffolding (chat-extraction markers, user-facing notes) has been removed.
+
+Future M3 milestones (M3.A2 through M3.A10) should follow this pattern: the execution prompt gets committed to `_plan/` at the start of the milestone, not left in chat.
+
+## 1. Role and scope
+
+You are executing M3.A1 of the Malaysia Secure Exchange Platform (SEP). The authoritative plan is `_plan/M3_EXECUTION_PLAN.md` at main commit `5a5f0c1`. Read §5 M3.A1 in full before starting any task. Also read §2.1 (tenancy model), §7.1 (Prisma model additions), §7.4 (migration ordering), and §10.1 (self-review discipline) — these are prerequisite context.
+
+M3.A1 is "Database tenant isolation (RLS)." Scope is strictly tasks T01–T06 per plan §5. Not executing M3.A2 or later in this session.
+
+## 2. Repository state at start (initial session — 2026-04-18)
+
+- Main HEAD: `5a5f0c1` (merge commit of PR #20)
+- Tag `post-m3.0-baseline` at `ca5d3d9` (historical reference)
+- M3.A0 closed: issue #16 closed; `verify-m3-0-findings.mjs` exits 0 (25/0/0)
+- Main CI: 8/8 green on push-to-main
+- Open issues:
+  - #8 — tests/helpers lint scope (M3.A8; NOT this session)
+  - #18 — format:check not in lefthook (M3 dev-workflow; NOT this session)
+  - #19 — develop branch referenced but doesn't exist (M3 followup; NOT this session)
+  - #21 — build pipeline stale tsbuildinfo (filed during first session; NOT blocking this work)
+
+**Resume state (if starting from a cleared session after the first session's T01 landed):**
+
+- Branch: `m3.a1/rls-tenant-isolation` (pushed to `origin`, tracking set)
+- T01 committed: `b608637` (`feat(m3.a1): separate sep_app runtime role from migration role`)
+- Remaining: T02, T03, T04, T05, T06, PR creation
+- Pre-execution checklist §4 already passed once in the first session; safe to skip items 1–6, but re-run item #7 (Tenant.id type confirmation) if `schema.prisma` has been touched since
+- Build-pipeline workaround: `rm -rf <pkg>/dist/` before `pnpm run build` if seeing stale tsbuildinfo (issue #21 tracks proper fix)
+
+## 3. Critical correction to plan §2.1 and §7.4
+
+Plan §2.1 RLS policy pattern shows `current_setting('app.current_tenant_id', true)::uuid`. **This is wrong.** `Tenant.id` in the current schema is `@default(cuid())`, not UUID. Casting a cuid to UUID via `::uuid` throws on every non-NULL value — so policies written with that pattern would reject every query, not just unauthenticated ones.
+
+Use this corrected policy pattern:
+
+```sql
+CREATE POLICY <table>_tenant_select ON <table>
+  FOR SELECT USING (
+    tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')
+  );
+```
+
+Why this works:
+
+- `current_setting('app.current_tenant_id', true)` returns empty string when unset (the `true` parameter makes it non-throwing)
+- `NULLIF(value, '')` converts the empty string to NULL
+- `tenant_id = NULL` evaluates to NULL under SQL three-valued logic — the row is NOT returned (fail-closed)
+- When tenant is set, comparison is string-to-string against a cuid column — this works correctly
+
+Apply this same pattern to all four operations (SELECT, INSERT, UPDATE, DELETE). For INSERT WITH CHECK and UPDATE WITH CHECK, wrap the same NULLIF expression.
+
+The corresponding runtime contract: `SET LOCAL app.current_tenant_id = '<tenant-cuid>'` — pass the raw cuid string, no casting. If tenantId validation is desired at the service layer (and it should be), use Zod `.regex(/^c[a-z0-9]{24,}$/)` or the cuid library's validator — NOT UUID regex.
+
+If during execution this pattern doesn't work against actual Prisma session behavior (e.g., pg connection pooling recycles session vars in an unexpected way), STOP AND REPORT — systems-level behavior worth discussing before improvising.
+
+## 4. Pre-execution safety checklist
+
+Run before starting T01. If any check fails, STOP AND REPORT before making any change.
+
+Skip checks 1–6 on session resume (the first session already passed them). Always re-run check #7.
+
+1. Branch and main state clean:
+
+   ```
+   git fetch origin
+   git log --oneline origin/main -5     # expect: 5a5f0c1 as HEAD
+   ```
+
+2. Baseline gates pass on main:
+
+   ```
+   pnpm install --frozen-lockfile
+   pnpm run typecheck     # expect: 15/15
+   pnpm run lint          # expect: 15/15
+   pnpm run format:check  # expect: pass
+   pnpm run build         # expect: 9/9
+   pnpm run test:unit     # expect: 14/14
+   node _plan/scripts/verify-m3-0-findings.mjs   # expect: 25/0/0 exit 0
+   ```
+
+3. M3.A0 `tsc -b` still works (T01–T04 output):
+
+   ```
+   pnpm exec tsc -b tsconfig.solution.json    # expect: exit 0
+   ```
+
+4. Infra containers reachable:
+
+   ```
+   docker compose up -d postgres redis
+   docker compose ps     # expect: both healthy
+   ```
+
+5. Current Prisma schema is migrate-deploy clean:
+
+   ```
+   docker compose exec postgres psql -U <admin-user> -c "DROP DATABASE IF EXISTS sep_test;"
+   docker compose exec postgres psql -U <admin-user> -c "CREATE DATABASE sep_test;"
+   DATABASE_URL=postgres://.../sep_test pnpm prisma migrate deploy
+   # expect: all existing migrations apply cleanly, exit 0
+   ```
+
+6. Test Postgres admin role is reachable for creating `sep` and `sep_app` roles during T01.
+
+7. Tenant.id type (ALWAYS re-run on session resume):
+   ```
+   grep -A 2 "model Tenant {" packages/db/prisma/schema.prisma | head -5
+   # expect: "id  String  @id @default(cuid())" — NOT @default(uuid())
+   # Confirms the §3 correction is still needed.
+   ```
+
+## 5. Absolute rules
+
+1. **Scope lock.** Execute ONLY M3.A1-T01 through M3.A1-T06 per plan §5 acceptance criteria. Anything that looks adjacent but is §M3.A2+ scope — stop and escalate.
+
+2. **One task per commit**, except where a within-scope follow-up emerges (same T01b / T03b pattern used in M3.A0 is acceptable).
+
+3. **Option (ii) self-review discipline activates.** Per plan §10.1, any PR touching `packages/db/prisma/migrations/`, `packages/crypto/`, or `apps/control-plane/src/modules/auth/` requires a self-review block. M3.A1-T02 is the first commit in this PR touching the first of those paths. Self-review mechanics in §8.
+
+4. **Stop-and-report triggers:**
+   - Any acceptance criterion in plan §5 can't be met as written
+   - Any local gate fails (`pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check`, `pnpm run build`, `pnpm run test:unit`)
+   - Any migration test failure that isn't obviously a fixture problem
+   - Any unexpected Postgres error during RLS policy creation
+   - Any pg connection pool recycling / SET LOCAL scope surprise
+   - §3 correction proves insufficient or produces unexpected behavior
+   - Any specific RLS gotcha in §7 surfaces
+
+5. **No gate bypass.** No `--no-verify` commits. No commenting out failing tests.
+
+6. **Branch strategy.** Branch `m3.a1/rls-tenant-isolation` (already exists on origin from first session). All T-task commits land on it. ONE PR at end of M3.A1, not per-task.
+
+## 6. Task-by-task execution order
+
+Plan §5 M3.A1-T01 through M3.A1-T06 in order. Plan's acceptance criteria are binding. This prompt adds context and gotchas; it does not replace plan.
+
+**T01 — Runtime role separation (`sep_app` vs `sep`)** — Already committed as `b608637` in the first session. Skip on resume.
+
+**T02 — Denormalize tenantId onto FK-scoped tables**
+
+Per plan §5. Schema + migration. Two tables get new `tenantId` column: `delivery_attempts` (backfill from `submission.tenantId`), `webhook_delivery_attempts` (backfill from `webhook.tenantId`, fallback to `submission.tenantId` when `webhookId` is null).
+
+Backfill in the migration, not in application code. Add `@@index([tenantId])` on both tables. Plan acceptance criteria are the bar.
+
+**This is the first PR-candidate commit touching `packages/db/prisma/migrations/`.** Self-review discipline activates from T02 onward for every migration commit. Self-review block gets written at PR creation (after T06), not on each commit.
+
+**T03 — Add RefreshToken model with denormalized tenantId**
+
+Per plan §5. New model with tenantId from creation. RLS policies for RefreshToken are in THIS migration, not a follow-up — consistency-by-construction.
+
+**T04 — Enable RLS + policies on all 18 tables**
+
+Per plan §5. High-volume mechanical migration (72 policies: 18 tables × 4 operations). Must be atomic (`BEGIN ... COMMIT`). Use the CORRECTED policy pattern (NULLIF-based, not UUID-cast) per §3.
+
+After migration applies:
+
+```sql
+SELECT tablename, policyname, cmd FROM pg_policies ORDER BY tablename, policyname;
+-- Expect: 72 rows, 4 per table × 18 tables
+```
+
+**T05 — DatabaseService.forTenant() with SET LOCAL**
+
+Per plan §5. Runtime path for setting tenant session variable. Uses `$transaction`. Throws `SepError.of('TENANT_CONTEXT_INVALID', ...)` on malformed tenantId — but since tenantId is cuid, validation is cuid-shaped, not UUID-shaped. If existing schemas already have a cuid validator, reuse; otherwise add one to `packages/schemas/`.
+
+Integration test: tenant A context queries return only tenant A rows; tenant B rows invisible even in the same table.
+
+**T06 — Cross-tenant negative test suite**
+
+Per plan §5. 144 assertions (18 tables × 8 operations). New directory `tests/integration/rls-negative-tests/`.
+
+Use a test helper to generate 8 assertions per table consistently; don't hand-write 144 nearly-identical test bodies. Pattern:
+
+```typescript
+// tests/integration/rls-negative-tests/_helpers/rls-assertions.ts
+export function assertsRlsOnTable(tableName: string, seedFn: ...) {
+  it(`${tableName}: SELECT without tenant context returns 0 rows`, async () => { ... });
+  it(`${tableName}: INSERT without tenant context fails`, async () => { ... });
+  // ... 6 more
+}
+```
+
+Each of 18 per-table files calls `assertsRlsOnTable('users', ...)` etc.
+
+## 7. RLS gotcha index
+
+Before writing any RLS policy or SET LOCAL call, internalize this list. If you find yourself working on anything resembling one of these, slow down:
+
+1. **Forgotten `FORCE ROW LEVEL SECURITY`.** `ENABLE ROW LEVEL SECURITY` alone allows superusers (and table owner) to bypass policies. `FORCE` is required for policies to apply to all roles. Every table in T04 needs BOTH `ENABLE` and `FORCE`.
+
+2. **Wrong NULL-handling in policy expression.** The §3 corrected pattern (NULLIF + string comparison) fails closed on empty/unset. Deviating from this pattern risks silent-leak — SELECT without tenant context returning all rows.
+
+3. **SET LOCAL scope vs SET scope.** `SET LOCAL` is transaction-scoped; `SET` is session-scoped. With pg connection pooling, `SET` leaks tenant context across unrelated requests on the same connection. Use `SET LOCAL` exclusively inside `$transaction`.
+
+4. **Policy creation outside transaction during T04.** T04 creates 72 policies across 18 tables. Without `BEGIN ... COMMIT`, a failure partway leaves the database with partial policies — a hybrid state worse than either all-on or all-off. Migration MUST be atomic.
+
+5. **Prisma and SET LOCAL interaction.** Prisma's `$transaction` wraps queries in BEGIN/COMMIT. `SET LOCAL` inside is scoped to that transaction. BUT: verify Prisma issues the `$executeRaw SET LOCAL` and subsequent queries on the same pool connection. Use `$queryRaw("SELECT current_setting('app.current_tenant_id', true)")` right before and right after the SET LOCAL to confirm.
+
+6. **BYPASSRLS attribute on the wrong role.** `sep_app` (runtime) MUST NOT have `BYPASSRLS`. `sep` (migration) MAY have `BYPASSRLS` — but per Postgres defaults, the database owner has implicit BYPASSRLS regardless of attribute setting. Confirm with:
+
+   ```sql
+   SELECT rolname, rolbypassrls FROM pg_roles WHERE rolname IN ('sep', 'sep_app');
+   ```
+
+7. **WITH CHECK vs USING for UPDATE and INSERT.** UPDATE policy needs BOTH `USING` (which rows are visible to update) and `WITH CHECK` (what the row must look like after update). INSERT policy only needs `WITH CHECK`. Missing `WITH CHECK` on UPDATE allows moving a row FROM tenant A TO tenant B — a subtle data-leak variant.
+
+8. **Testing RLS with the wrong role.** Integration tests must connect as `sep_app`, NOT the Postgres superuser. Superusers have implicit BYPASSRLS; tests running as superuser will show all rows regardless of policy and give false confidence.
+
+9. **Migration reversibility.** Plan §7.4 specifies: "Migration's `down` disables policies rather than dropping." Use `DISABLE ROW LEVEL SECURITY` in down migrations — reversible by re-enabling. `DROP POLICY` requires knowing full policy body to recreate.
+
+10. **Policy naming.** Plan pattern is `<table>_tenant_<op>` (e.g., `users_tenant_select`). Postgres scopes policy names per-table, so two tables can both have `<t>_tenant_select` without collision. Stick to the plan pattern; don't deviate.
+
+## 8. Self-review mechanics — option (ii)
+
+**When to write the self-review block:** at PR creation, not at merge time. The block goes in the PR body.
+
+**What the block must contain** (three sub-headings, each with substantive content):
+
+```markdown
+## Self-review (§10.1 option ii)
+
+### Threat model considered
+
+What attack surface does this change touch? Which OWASP API Top 10 2023
+category is relevant? If none, state explicitly.
+
+- Attack surface: [specific, not generic]
+- OWASP category: [e.g., A01:2021 Broken Access Control, or "not applicable because X"]
+- CWE relevant: [e.g., CWE-284]
+
+### Test coverage added
+
+What tests prove this change behaves correctly? What negative/failure
+cases are covered? If a class of failure is NOT covered, say why (and
+file a follow-up issue if meaningful).
+
+- Tests added: [file names + assertion counts]
+- Negative cases covered: [enumerate]
+- Not covered: [enumerate + rationale]
+
+### Rollback path documented
+
+If this change is bad, what's the fix? Migration reversal? Feature-flag
+toggle? Re-deploy previous commit? Some changes are not rollback-safe —
+if so, state explicitly and name compensating controls.
+
+- Rollback method: [e.g., prisma migrate reset + replay without T04 migration]
+- Compensating controls if not rollback-safe: [if applicable]
+```
+
+**Before requesting self-approval:**
+
+1. Write the block in the PR body at PR creation time.
+2. Wait overnight if possible; minimum 2 hours between writing and re-reading.
+3. Re-read your own PR body with fresh eyes, particularly the self-review block.
+4. If re-reading surfaces a gap (missed threat-model angle, untested case, glossed rollback step) — either add commits to fix it OR explicitly note "known limitation" in the PR body.
+5. Only after step 3–4, request self-review via GitHub UI (same action as requesting any CODEOWNER).
+6. Approve and merge — but only after step 3–4 is satisfied.
+
+If re-reading surfaces real concerns: STOP AND REPORT. Don't merge against your own doubt.
+
+## 9. PR creation
+
+After T06 commits:
+
+- Open ONE PR from `m3.a1/rls-tenant-isolation` to `main`
+- Title: `feat(m3.a1): database tenant isolation via RLS (PRIOR-R2-001 + PRIOR-R3-001)`
+- Body sections:
+  1. Summary — one paragraph
+  2. Task table — T01–T06 with commit SHAs
+  3. **Self-review (§10.1 option ii)** — three sub-sections per §8
+  4. Verify output — re-run `verify-m3-0-findings.mjs`, expected still 25/0/0
+  5. Closures — `Closes PRIOR-R2-001 and PRIOR-R3-001 per milestone exit criteria`
+  6. Follow-up issues — any surfaced during execution
+
+**Wait overnight between PR creation and requesting self-approval.** Non-negotiable per §10.1.
+
+## 10. End-of-session deliverables
+
+Report in chat when ready for review:
+
+1. PR number + URL
+2. All commit SHAs in order
+3. Verify script output from PR tip (expected still 25/0/0)
+4. PR CI status (expected: 8/8 green + the new `rls-negative-tests` job if plan §9 required check was added)
+5. Self-review block (copy-paste the three sub-sections from PR body)
+6. Confirmation of overnight re-read period completed before requesting self-approval
+7. Any stop-and-report items handled during session, summarized
+8. Any new follow-up issues filed
+
+Then stop. Do not merge without explicit approval. Do not proceed to M3.A2.

--- a/apps/data-plane/src/processors/delivery.processor.test.ts
+++ b/apps/data-plane/src/processors/delivery.processor.test.ts
@@ -107,10 +107,11 @@ describe('DeliveryProcessor', () => {
   it('delivers successfully and updates submission to SENT', async () => {
     await processor.process(makeJob());
 
-    // DeliveryAttempt created
+    // DeliveryAttempt created — tenantId must be denormalized from the job
     expect(mockDeliveryAttemptCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
+          tenantId: 'tenant-001',
           submissionId: 'sub-001',
           attemptNo: 1,
           connectorType: 'SFTP',

--- a/apps/data-plane/src/processors/delivery.processor.ts
+++ b/apps/data-plane/src/processors/delivery.processor.ts
@@ -117,6 +117,7 @@ export class DeliveryProcessor extends WorkerHost {
     // 4. Create DeliveryAttempt record before attempting
     const deliveryAttempt = await db.deliveryAttempt.create({
       data: {
+        tenantId,
         submissionId,
         attemptNo: attempt,
         startedAt: new Date(),

--- a/apps/data-plane/src/processors/inbound.processor.test.ts
+++ b/apps/data-plane/src/processors/inbound.processor.test.ts
@@ -174,6 +174,7 @@ describe('InboundProcessor', () => {
     mockWebhookFindMany.mockResolvedValue([
       {
         id: 'wh-001',
+        tenantId: 'tenant-001',
         url: 'https://callback.example.com/hook',
         events: ['SUBMISSION_ACK_RECEIVED'],
       },
@@ -183,9 +184,11 @@ describe('InboundProcessor', () => {
 
     await processor.process(makeJob());
 
+    // tenantId must be denormalized from the parent webhook (M3.A1-T02)
     expect(mockWebhookAttemptCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
+          tenantId: 'tenant-001',
           webhookId: 'wh-001',
           submissionId: 'sub-001',
           eventType: 'SUBMISSION_ACK_RECEIVED',
@@ -198,6 +201,7 @@ describe('InboundProcessor', () => {
     mockWebhookFindMany.mockResolvedValue([
       {
         id: 'wh-001',
+        tenantId: 'tenant-001',
         url: 'https://callback.example.com/hook',
         events: ['SUBMISSION_ACK_RECEIVED'],
       },

--- a/apps/data-plane/src/processors/inbound.processor.ts
+++ b/apps/data-plane/src/processors/inbound.processor.ts
@@ -389,6 +389,7 @@ export class InboundProcessor extends WorkerHost {
         // Create webhook delivery attempt (actual HTTP dispatch delegated to webhook service)
         await db.webhookDeliveryAttempt.create({
           data: {
+            tenantId: webhook.tenantId,
             webhookId: webhook.id,
             submissionId: submission.id,
             eventType: 'SUBMISSION_ACK_RECEIVED',

--- a/infra/postgres/init.sql
+++ b/infra/postgres/init.sql
@@ -39,6 +39,15 @@ BEGIN
 END
 $$;
 
+-- M3.A1-T01: Make BYPASSRLS attributes explicit on both roles.
+--   sep is also a SUPERUSER (inherited from POSTGRES_USER), so BYPASSRLS is
+--   implicit — but the plan (§2.1) requires it to be set explicitly so that
+--   changes to the SUPERUSER attribute don't accidentally flip RLS bypass
+--   behaviour. sep_app is never allowed to bypass RLS; NOBYPASSRLS +
+--   NOSUPERUSER is enforced as defence-in-depth against future misconfig.
+ALTER ROLE sep WITH BYPASSRLS;
+ALTER ROLE sep_app WITH NOBYPASSRLS NOSUPERUSER;
+
 GRANT CONNECT ON DATABASE sep_dev TO sep_app;
 GRANT USAGE ON SCHEMA public TO sep_app;
 

--- a/packages/db/prisma/migrations/20260418221717_denormalize_tenant_id/migration.sql
+++ b/packages/db/prisma/migrations/20260418221717_denormalize_tenant_id/migration.sql
@@ -1,0 +1,49 @@
+-- M3.A1-T02: Denormalize tenantId onto FK-scoped tables
+--
+-- Adds tenantId column to delivery_attempts and webhook_delivery_attempts,
+-- backfills from the parent FK (submissions for delivery, webhooks for
+-- webhook delivery), then enforces NOT NULL and adds FK + index. The NOT
+-- NULL is deferred until after backfill so the migration is safe against
+-- non-empty tables. Prisma's default wraps migration SQL in BEGIN/COMMIT,
+-- giving the whole operation atomic-or-rollback semantics.
+--
+-- Scope: PRIOR-R2-001 + PRIOR-R3-001 (M3.A1 RLS single-column-predicate
+-- precondition). The RLS policies themselves land in M3.A1-T04.
+
+-- delivery_attempts.tenantId ─────────────────────────────────────────────
+ALTER TABLE "delivery_attempts" ADD COLUMN "tenantId" TEXT;
+
+UPDATE "delivery_attempts" da
+SET "tenantId" = s."tenantId"
+FROM "submissions" s
+WHERE da."submissionId" = s."id";
+
+ALTER TABLE "delivery_attempts" ALTER COLUMN "tenantId" SET NOT NULL;
+
+ALTER TABLE "delivery_attempts"
+ADD CONSTRAINT "delivery_attempts_tenantId_fkey"
+FOREIGN KEY ("tenantId") REFERENCES "tenants"("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "delivery_attempts_tenantId_idx" ON "delivery_attempts"("tenantId");
+
+-- webhook_delivery_attempts.tenantId ─────────────────────────────────────
+-- webhook_delivery_attempts.webhookId is NOT NULL in the current schema,
+-- so we backfill exclusively from webhooks.tenantId. Plan §5 mentions a
+-- submissions fallback for webhookId-null rows, but the schema does not
+-- permit null webhookId; that fallback is unreachable in the real data.
+ALTER TABLE "webhook_delivery_attempts" ADD COLUMN "tenantId" TEXT;
+
+UPDATE "webhook_delivery_attempts" wda
+SET "tenantId" = w."tenantId"
+FROM "webhooks" w
+WHERE wda."webhookId" = w."id";
+
+ALTER TABLE "webhook_delivery_attempts" ALTER COLUMN "tenantId" SET NOT NULL;
+
+ALTER TABLE "webhook_delivery_attempts"
+ADD CONSTRAINT "webhook_delivery_attempts_tenantId_fkey"
+FOREIGN KEY ("tenantId") REFERENCES "tenants"("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "webhook_delivery_attempts_tenantId_idx" ON "webhook_delivery_attempts"("tenantId");

--- a/packages/db/prisma/migrations/20260418222436_refresh_tokens_model/migration.sql
+++ b/packages/db/prisma/migrations/20260418222436_refresh_tokens_model/migration.sql
@@ -1,0 +1,66 @@
+-- M3.A1-T03: RefreshToken model + RLS policies (consistency-by-construction)
+--
+-- Creates refresh_tokens for M3.A4 auth-lifecycle consumption. The table
+-- includes tenantId denormalized from creation, and its RLS policies are
+-- defined in this same migration so the table never exists without RLS.
+--
+-- Policy predicate uses NULLIF(current_setting(...), '')-based comparison
+-- against a cuid-shaped tenant id, per plan §2.1 as corrected in
+-- _plan/M3_A1_EXECUTION_PROMPT.md §3. Do NOT use ::uuid cast — Tenant.id
+-- is @default(cuid()), not UUID.
+--
+-- Prisma migrate deploy wraps this migration in BEGIN/COMMIT by default,
+-- so CREATE TABLE + ENABLE RLS + CREATE POLICY are atomic.
+
+-- CreateTable
+CREATE TABLE "refresh_tokens" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "replacedById" TEXT,
+    "revokedAt" TIMESTAMP(3),
+    "revocationReason" TEXT,
+
+    CONSTRAINT "refresh_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "refresh_tokens_tokenHash_key" ON "refresh_tokens"("tokenHash");
+CREATE INDEX "refresh_tokens_tenantId_idx" ON "refresh_tokens"("tenantId");
+CREATE INDEX "refresh_tokens_userId_idx" ON "refresh_tokens"("userId");
+CREATE INDEX "refresh_tokens_expiresAt_idx" ON "refresh_tokens"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "refresh_tokens"
+ADD CONSTRAINT "refresh_tokens_tenantId_fkey"
+FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "refresh_tokens"
+ADD CONSTRAINT "refresh_tokens_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Row-Level Security — enabled + forced from creation
+ALTER TABLE "refresh_tokens" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "refresh_tokens" FORCE ROW LEVEL SECURITY;
+
+-- Policies — tenant-scoped, fail-closed on missing session variable
+CREATE POLICY "refresh_tokens_tenant_select" ON "refresh_tokens"
+  FOR SELECT
+  USING ("tenantId" = NULLIF(current_setting('app.current_tenant_id', true), ''));
+
+CREATE POLICY "refresh_tokens_tenant_insert" ON "refresh_tokens"
+  FOR INSERT
+  WITH CHECK ("tenantId" = NULLIF(current_setting('app.current_tenant_id', true), ''));
+
+CREATE POLICY "refresh_tokens_tenant_update" ON "refresh_tokens"
+  FOR UPDATE
+  USING ("tenantId" = NULLIF(current_setting('app.current_tenant_id', true), ''))
+  WITH CHECK ("tenantId" = NULLIF(current_setting('app.current_tenant_id', true), ''));
+
+CREATE POLICY "refresh_tokens_tenant_delete" ON "refresh_tokens"
+  FOR DELETE
+  USING ("tenantId" = NULLIF(current_setting('app.current_tenant_id', true), ''));

--- a/packages/db/prisma/migrations/20260418222953_enable_rls_tenant_tables/migration.sql
+++ b/packages/db/prisma/migrations/20260418222953_enable_rls_tenant_tables/migration.sql
@@ -1,0 +1,109 @@
+-- M3.A1-T04: Enable RLS + 4 policies (SELECT/INSERT/UPDATE/DELETE) on
+-- all 17 remaining tenant-scoped tables. refresh_tokens was set up in
+-- M3.A1-T03 (consistency-by-construction from its creating migration),
+-- so it is NOT re-enabled here. End state after this migration:
+--
+--   17 tables × 4 tenant policies  = 68 policies (this migration)
+--   refresh_tokens × 4              =  4 policies (T03)
+--   audit_events existing deny/allow = 3 policies (baseline M3.0)
+--                                    ────
+--   total pg_policies rows          = 75
+--
+-- The 72 tenant-scoped policies demanded by plan §5-T04 acceptance are
+-- 18 tables × 4 operations = 72. Those are 68 (this migration) + 4 (T03).
+-- The 3 baseline audit_events policies are unrelated to tenant scoping
+-- and live alongside the tenant-scoped ones; per plan §2.1 they coexist
+-- intentionally, with REVOKE + BEFORE-UPDATE/DELETE triggers as the
+-- append-only defence-in-depth.
+--
+-- Atomicity: wrapped in a DO $$ block so any failure rolls back the
+-- entire migration. Plan §7 gotcha #4 — partial-state RLS across tables
+-- would be worse than either all-on or all-off.
+--
+-- Policy predicate: NULLIF(current_setting('app.current_tenant_id', true), '')
+-- rather than the plan §2.1 ::uuid cast. Tenant.id is @default(cuid()),
+-- not UUID — ::uuid would throw on every valid tenant. See
+-- _plan/M3_A1_EXECUTION_PROMPT.md §3 for the correction.
+--
+-- Rollback: prefer `ALTER TABLE ... DISABLE ROW LEVEL SECURITY` over
+-- `DROP POLICY` per plan §7.4 — disabling is reversible by re-enabling
+-- without reconstructing policy bodies. See the companion rollback
+-- sketch at the bottom of this file (commented, not executed).
+
+DO $$
+DECLARE
+  t TEXT;
+  tables TEXT[] := ARRAY[
+    'users',
+    'role_assignments',
+    'retention_policies',
+    'source_systems',
+    'partner_profiles',
+    'exchange_profiles',
+    'submissions',
+    'inbound_receipts',
+    'key_references',
+    'crypto_operation_records',
+    'audit_events',
+    'incidents',
+    'approvals',
+    'webhooks',
+    'api_keys',
+    'delivery_attempts',
+    'webhook_delivery_attempts'
+  ];
+BEGIN
+  FOREACH t IN ARRAY tables
+  LOOP
+    -- Enable + FORCE: gotcha #1 — plain ENABLE lets the table owner
+    -- bypass policies. FORCE applies them to every role including owner.
+    EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', t);
+    EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY', t);
+
+    EXECUTE format(
+      'CREATE POLICY %I ON %I FOR SELECT USING ("tenantId" = NULLIF(current_setting(''app.current_tenant_id'', true), %L))',
+      t || '_tenant_select',
+      t,
+      ''
+    );
+
+    EXECUTE format(
+      'CREATE POLICY %I ON %I FOR INSERT WITH CHECK ("tenantId" = NULLIF(current_setting(''app.current_tenant_id'', true), %L))',
+      t || '_tenant_insert',
+      t,
+      ''
+    );
+
+    -- UPDATE needs BOTH USING and WITH CHECK — gotcha #7. Without
+    -- WITH CHECK, a row could be updated to move it FROM tenant A
+    -- TO tenant B; USING alone only constrains which rows are visible
+    -- for update, not the post-update state.
+    EXECUTE format(
+      'CREATE POLICY %I ON %I FOR UPDATE USING ("tenantId" = NULLIF(current_setting(''app.current_tenant_id'', true), %L)) WITH CHECK ("tenantId" = NULLIF(current_setting(''app.current_tenant_id'', true), %L))',
+      t || '_tenant_update',
+      t,
+      '',
+      ''
+    );
+
+    EXECUTE format(
+      'CREATE POLICY %I ON %I FOR DELETE USING ("tenantId" = NULLIF(current_setting(''app.current_tenant_id'', true), %L))',
+      t || '_tenant_delete',
+      t,
+      ''
+    );
+  END LOOP;
+END $$;
+
+-- Rollback sketch (not executed — retained for reviewers):
+--
+-- DO $$
+-- DECLARE
+--   t TEXT;
+--   tables TEXT[] := ARRAY[...same list as above...];
+-- BEGIN
+--   FOREACH t IN ARRAY tables
+--   LOOP
+--     EXECUTE format('ALTER TABLE %I DISABLE ROW LEVEL SECURITY', t);
+--   END LOOP;
+-- END $$;

--- a/packages/db/prisma/migrations/20260418222953_enable_rls_tenant_tables/migration.sql
+++ b/packages/db/prisma/migrations/20260418222953_enable_rls_tenant_tables/migration.sql
@@ -5,9 +5,12 @@
 --
 --   17 tables × 4 tenant policies  = 68 policies (this migration)
 --   refresh_tokens × 4              =  4 policies (T03)
---   audit_events existing deny/allow = 3 policies (baseline M3.0)
+--   audit_events baseline M3.0      =  4 policies (audit_insert_only,
+--                                                  audit_allow_select,
+--                                                  audit_deny_update,
+--                                                  audit_deny_delete)
 --                                    ────
---   total pg_policies rows          = 75
+--   total pg_policies rows          = 76
 --
 -- The 72 tenant-scoped policies demanded by plan §5-T04 acceptance are
 -- 18 tables × 4 operations = 72. Those are 68 (this migration) + 4 (T03).

--- a/packages/db/prisma/migrations/20260418222953_enable_rls_tenant_tables/migration.sql
+++ b/packages/db/prisma/migrations/20260418222953_enable_rls_tenant_tables/migration.sql
@@ -11,10 +11,24 @@
 --
 -- The 72 tenant-scoped policies demanded by plan §5-T04 acceptance are
 -- 18 tables × 4 operations = 72. Those are 68 (this migration) + 4 (T03).
--- The 3 baseline audit_events policies are unrelated to tenant scoping
--- and live alongside the tenant-scoped ones; per plan §2.1 they coexist
--- intentionally, with REVOKE + BEFORE-UPDATE/DELETE triggers as the
--- append-only defence-in-depth.
+--
+-- audit_events — RLS-semantics correction. Postgres combines permissive
+-- policies with OR. Adding tenant_update and tenant_delete policies
+-- alongside the M3.0 baseline deny-all policies would DEFEAT the
+-- deny-all (tenant policy returning true OR deny-all returning false
+-- evaluates to true), opening an append-violation vector that didn't
+-- exist before this migration.
+--
+-- The fix (immediately after the DO $$ block): REVOKE UPDATE, DELETE,
+-- INSERT ON audit_events FROM sep_app. This operates at the grant
+-- layer, not RLS, and is not subject to OR-combination. Writes become
+-- structurally impossible regardless of what any RLS policy says.
+--
+-- The tenant policies remain in place on audit_events for consistency
+-- with the other 17 tables; they cannot fire because sep_app has no
+-- write grants. M3.A2 will restore GRANT INSERT ON audit_events TO
+-- sep_app (AuditService writes via parent transaction) and drop the
+-- redundant M3.0 baseline deny-all RLS policies at that point.
 --
 -- Atomicity: wrapped in a DO $$ block so any failure rolls back the
 -- entire migration. Plan §7 gotcha #4 — partial-state RLS across tables
@@ -27,8 +41,10 @@
 --
 -- Rollback: prefer `ALTER TABLE ... DISABLE ROW LEVEL SECURITY` over
 -- `DROP POLICY` per plan §7.4 — disabling is reversible by re-enabling
--- without reconstructing policy bodies. See the companion rollback
--- sketch at the bottom of this file (commented, not executed).
+-- without reconstructing policy bodies. The audit_events REVOKE is
+-- reversible via `GRANT UPDATE, DELETE, INSERT ON audit_events TO
+-- sep_app`. See the companion rollback sketch at the bottom of this
+-- file (commented, not executed).
 
 DO $$
 DECLARE
@@ -95,6 +111,12 @@ BEGIN
   END LOOP;
 END $$;
 
+-- audit_events write defense-in-depth — see header comment. Structural
+-- append-only enforcement at the grant layer, immune to RLS OR-combination
+-- with the M3.0 baseline deny-all policies. M3.A2 will restore INSERT
+-- for AuditService and drop the now-redundant baseline policies.
+REVOKE UPDATE, DELETE, INSERT ON "audit_events" FROM sep_app;
+
 -- Rollback sketch (not executed — retained for reviewers):
 --
 -- DO $$
@@ -107,3 +129,5 @@ END $$;
 --     EXECUTE format('ALTER TABLE %I DISABLE ROW LEVEL SECURITY', t);
 --   END LOOP;
 -- END $$;
+--
+-- GRANT UPDATE, DELETE, INSERT ON "audit_events" TO sep_app;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -244,6 +244,7 @@ model Tenant {
   cryptoOperationRecords  CryptoOperationRecord[]
   deliveryAttempts        DeliveryAttempt[]
   webhookDeliveryAttempts WebhookDeliveryAttempt[]
+  refreshTokens           RefreshToken[]
 
   @@index([status])
   @@map("tenants")
@@ -267,11 +268,37 @@ model User {
   // Named relations for Approval — uses only User.id, not compound key
   initiatedApprovals Approval[]       @relation("ApprovalInitiator")
   grantedApprovals   Approval[]       @relation("ApprovalApprover")
+  refreshTokens      RefreshToken[]
 
   @@unique([tenantId, email])
   @@index([tenantId])
   @@index([authSubject])
   @@map("users")
+}
+
+// ── Refresh Token — M3.A1-T03, consumed by M3.A4 auth lifecycle ───────────────
+// Stored as argon2id hash of the raw token; raw value is never at rest.
+// tenantId denormalized from creation for RLS single-column predicate.
+
+model RefreshToken {
+  id               String    @id @default(cuid())
+  tenantId         String
+  userId           String
+  tokenHash        String    @unique // argon2id of raw token
+  issuedAt         DateTime  @default(now())
+  expiresAt        DateTime
+  usedAt           DateTime?
+  replacedById     String?
+  revokedAt        DateTime?
+  revocationReason String?
+
+  tenant Tenant @relation(fields: [tenantId], references: [id])
+  user   User   @relation(fields: [userId], references: [id])
+
+  @@index([tenantId])
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("refresh_tokens")
 }
 
 model RoleAssignment {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -242,6 +242,8 @@ model Tenant {
   apiKeys                 ApiKey[]
   inboundReceipts         InboundReceipt[]
   cryptoOperationRecords  CryptoOperationRecord[]
+  deliveryAttempts        DeliveryAttempt[]
+  webhookDeliveryAttempts WebhookDeliveryAttempt[]
 
   @@index([status])
   @@map("tenants")
@@ -437,6 +439,7 @@ model Submission {
 
 model DeliveryAttempt {
   id                  String          @id @default(cuid())
+  tenantId            String
   submissionId        String
   attemptNo           Int
   startedAt           DateTime        @default(now())
@@ -449,8 +452,10 @@ model DeliveryAttempt {
   durationMs          Int?
   metadata            Json?
 
+  tenant     Tenant     @relation(fields: [tenantId], references: [id])
   submission Submission @relation(fields: [submissionId], references: [id])
 
+  @@index([tenantId])
   @@index([submissionId])
   @@map("delivery_attempts")
 }
@@ -668,6 +673,7 @@ model Webhook {
 
 model WebhookDeliveryAttempt {
   id           String   @id @default(cuid())
+  tenantId     String
   webhookId    String
   submissionId String?
   eventType    String
@@ -678,9 +684,11 @@ model WebhookDeliveryAttempt {
   attemptedAt  DateTime @default(now())
   durationMs   Int?
 
+  tenant     Tenant      @relation(fields: [tenantId], references: [id])
   webhook    Webhook     @relation(fields: [webhookId], references: [id])
   submission Submission? @relation(fields: [submissionId], references: [id], onDelete: Restrict)
 
+  @@index([tenantId])
   @@index([webhookId])
   @@index([submissionId])
   @@map("webhook_delivery_attempts")

--- a/packages/db/src/role-separation.test.ts
+++ b/packages/db/src/role-separation.test.ts
@@ -1,0 +1,79 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+
+// eslint-disable-next-line no-process-env -- integration gate reads env directly
+const MIGRATION_URL = process.env['DATABASE_URL'];
+// eslint-disable-next-line no-process-env -- integration gate reads env directly
+const RUNTIME_URL = process.env['RUNTIME_DATABASE_URL'];
+
+const hasIntegrationEnv =
+  MIGRATION_URL !== undefined &&
+  MIGRATION_URL.length > 0 &&
+  RUNTIME_URL !== undefined &&
+  RUNTIME_URL.length > 0;
+
+interface RoleRow {
+  rolname: string;
+  rolsuper: boolean;
+  rolbypassrls: boolean;
+  rolcanlogin: boolean;
+}
+
+describe.skipIf(!hasIntegrationEnv)('role separation (M3.A1-T01)', () => {
+  // describe.skipIf marks tests as skipped but still evaluates the callback body.
+  // Conditional spread keeps PrismaClient happy under exactOptionalPropertyTypes
+  // when the env vars are unset — the skipped tests never actually connect.
+  const migrationClient = new PrismaClient({
+    ...(MIGRATION_URL !== undefined && { datasourceUrl: MIGRATION_URL }),
+  });
+  const runtimeClient = new PrismaClient({
+    ...(RUNTIME_URL !== undefined && { datasourceUrl: RUNTIME_URL }),
+  });
+
+  afterAll(async () => {
+    await migrationClient.$disconnect();
+    await runtimeClient.$disconnect();
+  });
+
+  it('sep role has BYPASSRLS attribute explicitly set', async () => {
+    const rows = await migrationClient.$queryRaw<RoleRow[]>`
+      SELECT rolname, rolsuper, rolbypassrls, rolcanlogin
+      FROM pg_roles
+      WHERE rolname = 'sep'
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.rolbypassrls).toBe(true);
+  });
+
+  it('sep_app role does NOT have BYPASSRLS attribute', async () => {
+    const rows = await migrationClient.$queryRaw<RoleRow[]>`
+      SELECT rolname, rolsuper, rolbypassrls, rolcanlogin
+      FROM pg_roles
+      WHERE rolname = 'sep_app'
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.rolbypassrls).toBe(false);
+    expect(rows[0]?.rolsuper).toBe(false);
+    expect(rows[0]?.rolcanlogin).toBe(true);
+  });
+
+  it('RUNTIME_DATABASE_URL connection reports current_user = sep_app', async () => {
+    const rows = await runtimeClient.$queryRaw<Array<{ current_user: string }>>`
+      SELECT current_user
+    `;
+    expect(rows[0]?.current_user).toBe('sep_app');
+  });
+
+  it('DATABASE_URL connection reports current_user = sep', async () => {
+    const rows = await migrationClient.$queryRaw<Array<{ current_user: string }>>`
+      SELECT current_user
+    `;
+    expect(rows[0]?.current_user).toBe('sep');
+  });
+
+  it('sep_app cannot CREATE TABLE (DDL is denied at schema level)', async () => {
+    await expect(
+      runtimeClient.$executeRawUnsafe('CREATE TABLE sep_app_ddl_probe (id text PRIMARY KEY);'),
+    ).rejects.toThrow(/permission denied/i);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the DB-layer half of PRIOR-R2-001 / PRIOR-R3-001 (CRITICAL, BOLA). Adds explicit `BYPASSRLS` role separation, denormalizes `tenantId` onto the two FK-scoped tables so RLS can use single-column predicates, adds the `RefreshToken` model with RLS from its creating migration, and turns on ROW LEVEL SECURITY + FORCE + tenant-scoped policies (SELECT/INSERT/UPDATE/DELETE) across all 18 tenant-scoped tables. End state: 72 tenant-scoped policies in `pg_policies`, fail-closed when tenant context is missing or wrong.

M3.A1 is delivered in three PRs — this is part 1 (DB layer). Part 2 (runtime `forTenant()` injection, ~40-caller refactor) ships in a separate PR after this one merges. Part 3 (144-assertion negative test suite) follows.

## Tasks in this PR

| Task | Commit | Description |
| ---- | ------ | ----------- |
| docs | `b643dd8` | Retroactively commit the M3.A1 execution prompt to `_plan/` so future sessions have the authoritative spec on disk, not in chat context. |
| T01 | `b608637` | `ALTER ROLE sep WITH BYPASSRLS`; `ALTER ROLE sep_app WITH NOBYPASSRLS NOSUPERUSER`. `.env.example` + `DatabaseService` split was already complete from M2. New integration test suite covers role attributes. |
| T02 | `925fa5f` | Denormalize `tenantId` onto `delivery_attempts` and `webhook_delivery_attempts` (backfilled in-migration from FK parent). Processor code updated to pass `tenantId` on writes; test assertions strengthened. |
| T03 | `c4c1b4e` | `RefreshToken` model for M3.A4 consumption; table creation and RLS policies land in the same migration (consistency-by-construction). |
| T04 | `d1b5af0` | Single atomic migration enabling RLS + FORCE on the remaining 17 tenant-scoped tables and creating 4 tenant policies each (68 here + 4 from T03 = 72 total). Uses corrected `NULLIF(current_setting(...), '')` predicate per execution prompt §3 (not `::uuid` — `Tenant.id` is cuid). |
| fix | `1676724` | Fix-up: REVOKE UPDATE, DELETE, INSERT on audit_events from sep_app to counter OR-combination of tenant policies with the M3.0 deny-all policies. See "RLS semantics correction" below. |
| docs | `ca7ca57` | Fix-up: correct baseline policy count (3→4, missed `audit_insert_only`), correct total `pg_policies` count (75→76), rewrite the audit_events threat-model paragraph to distinguish INSERT vs UPDATE/DELETE mechanisms, broaden the "known regression" wording. |
| docs | (this commit) | Fix-up: correct the SELECT bullet — `tenant_select` does NOT narrow visibility under permissive OR-combination. Verified live; security posture unchanged from M3.0 (service-layer tenant filtering is the actual SELECT-scoping mechanism). |

## Critical correction from plan §2.1

Plan §2.1 specifies an RLS policy predicate using `current_setting('app.current_tenant_id', true)::uuid`. This is wrong: `Tenant.id` is `@default(cuid())`, not UUID, and `::uuid` throws on every valid cuid. All 72 policies created by T03+T04 use `NULLIF(current_setting('app.current_tenant_id', true), '')` instead — which fails closed via SQL three-valued logic when the session variable is unset. Documented in `_plan/M3_A1_EXECUTION_PROMPT.md` §3 (committed in this PR's `b643dd8`).

## RLS semantics correction (commit `1676724`)

The initial T04 commit added tenant-scoped policies to `audit_events` alongside the M3.0 baseline policies and described them in the self-review as "overshadowed by" / "no-ops today." **That was factually wrong about Postgres RLS semantics for UPDATE and DELETE** (see the audit_events paragraph in the threat model section below for the corrected mechanism breakdown). The fix-up commit adds `REVOKE UPDATE, DELETE, INSERT ON audit_events FROM sep_app` immediately after the RLS policy creation. This operates at the grant layer, not RLS, and is not subject to OR-combination. Writes are structurally impossible regardless of what any policy says. The tenant RLS policies remain in place for table-level consistency but cannot fire because sep_app has no write grants. M3.A2 will restore `GRANT INSERT` (for `AuditService` writes via parent transaction) and drop the redundant M3.0 baseline deny-all RLS policies at that point.

**Known regression**: see the rewritten "Known regression" paragraph below (`ca7ca57` corrected the original framing).

## Self-review (§10.1 option ii)

### Threat model considered

- **Attack surface:** cross-tenant SELECT/INSERT/UPDATE/DELETE at the DB layer. Any runtime path that forgets to set tenant context (e.g., a handler using the raw Prisma client) would be visible here — with T01-T04 landed, such a path now returns 0 rows / fails a NOT NULL check / blocks the UPDATE rather than returning another tenant's data.
- **OWASP category:** A01:2021 Broken Access Control
- **CWE relevant:** CWE-284 (improper access control), CWE-639 (authorization bypass through user-controlled key)

Within-scope risks **not fully closed by this PR**:

1. Runtime path still uses the raw `DatabaseService.forTenant(tenantId)` → PrismaClient stub — no `SET LOCAL app.current_tenant_id` yet. That means RLS will fail-closed for every tenant-scoped query in production until PR #2 lands `forTenant` with real session-variable injection. Until then, the application will *function* (because `DatabaseService.forTenant` returns the raw client and the predicate checks happen in service code) but will *not* benefit from RLS defence-in-depth.

2. `audit_events` tenant policies interact with the M3.0 baseline as follows:
   - **UPDATE and DELETE:** M3.0 has deny-all policies (`USING false`). Tenant policies combined via OR would DEFEAT the deny-all — writes with correct tenant context would satisfy the tenant policy and proceed. Without the REVOKE, PR #1 opens UPDATE/DELETE paths that didn't exist in M3.0.
   - **INSERT:** M3.0 already permits INSERT (`audit_insert_only WITH CHECK (true)` + GRANT INSERT to sep_app). PR #1's `tenant_insert` policy doesn't change that. The REVOKE INSERT is a NEW restriction ahead of M3.A2 — functionally what we want (append-only discipline through AuditService) but not a defense against tenant policies.
   - **SELECT:** M3.0 permits SELECT for any role (`audit_allow_select USING (true)`). PR #1's `tenant_select` policy is added for table-level consistency with the other 17 tables, but does NOT narrow SELECT visibility — permissive policies are OR'd, so `(true) OR (tenantId=context) = true`, meaning sep_app continues to see all audit events regardless of tenant context. Service-layer tenant filtering in `AuditService` remains the actual SELECT-scoping mechanism. M3.A2 may revisit by making `audit_allow_select` restrictive or dropping it.

   The `REVOKE UPDATE, DELETE, INSERT ON audit_events FROM sep_app` is the defense-in-depth layer: grants are not subject to RLS OR-combination. M3.A2 will restore `GRANT INSERT` (for AuditService writes via parent transaction) and drop the redundant M3.0 baseline deny-all policies, at which point audit_events is on clean tenant-scoped RLS like every other table.

### Test coverage added

**Automated regression tests (CI-protected):**
- `packages/db/src/role-separation.test.ts` (T01) — 5 integration assertions: sep has explicit `BYPASSRLS`; sep_app has neither `BYPASSRLS` nor `SUPERUSER`; `RUNTIME_DATABASE_URL` reports `current_user = sep_app`; `DATABASE_URL` reports `current_user = sep`; sep_app cannot `CREATE TABLE`. Skipped cleanly when `DATABASE_URL`/`RUNTIME_DATABASE_URL` env vars are unset (unit-test compatibility).
- `delivery.processor.test.ts` + `inbound.processor.test.ts` (T02) — existing assertions strengthened to require `tenantId` in the `deliveryAttempt.create` and `webhookDeliveryAttempt.create` payloads, preventing regressions where the field gets dropped.

**Manual one-off verifications (not CI-protected — will become CI-protected when PR #3 lands the 144-assertion negative suite):**
- Migration replay on fresh DB — dropped and recreated `sep_dev` twice during execution; `prisma migrate deploy` applies all baseline + the three new M3.A1 migrations cleanly each time.
- `pg_policies` query post-T04: 18 tables × 4 tenant policies = 72 rows, plus the 4 baseline `audit_events` policies (`audit_insert_only`, `audit_allow_select`, `audit_deny_update`, `audit_deny_delete`). Total `pg_policies` rows = 76. All 18 tables show `relrowsecurity = t` and `relforcerowsecurity = t` in `pg_class`.
- Fail-closed behaviour as `sep_app`: `SELECT COUNT(*) FROM users` → 0 without tenant context; `BEGIN; SET LOCAL app.current_tenant_id = 'fake-tenant-id'; SELECT COUNT(*) FROM users; COMMIT;` → 0 with non-matching tenant.
- REVOKE verification post-fix-up: `information_schema.role_table_grants` shows sep_app has only `SELECT` on audit_events; INSERT attempt as sep_app with valid tenant context and valid enum value fails with `permission denied for table audit_events`.
- `audit_events` SELECT verification (round 3 fix-up): inserted two audit events (tenant-A, tenant-B) as sep, then queried as sep_app — both rows visible without tenant context AND with `SET LOCAL app.current_tenant_id = 'tenant-A'`. Confirms `tenant_select` is overshadowed by `audit_allow_select USING (true)` and SELECT scoping happens at the service layer, not RLS.

**Negative cases covered by automated tests in this PR:**
- Role attribute misconfiguration (T01 integration test)
- Missing `tenantId` in processor create calls (strengthened processor test assertions)

**Not covered in this PR (deferred intentionally):**
- The full 144-assertion cross-tenant negative suite — that's M3.A1-T06, PR #3. PR #1 covers *structural* correctness (policies exist, attributes correct, REVOKE applied); PR #3 covers *behavioural* correctness (every table fails closed in every cross-tenant scenario).
- Runtime tenant-context injection — M3.A1-T05, PR #2. Until that lands, RLS is structurally correct but not actively used by the application.
- Integration test for the `NULLIF` pattern actually behaving correctly under Prisma session semantics — covered in PR #2's integration test once `forTenant()` sets the session variable.

### Rollback path documented

- **Primary rollback:** `prisma migrate reset --force` replays the baseline + M3.A1 migrations from scratch; remove the three M3.A1 migration directories (`20260418221717_denormalize_tenant_id`, `20260418222436_refresh_tokens_model`, `20260418222953_enable_rls_tenant_tables`), revert `schema.prisma` and the two processor files, and re-run `prisma migrate deploy`. Prior M2 migrations are unaffected and the DB returns to pre-M3.A1 state.
- **Partial-rollback of T04 only:** the migration's rollback sketch is retained as commented SQL at the bottom of `20260418222953_enable_rls_tenant_tables/migration.sql` — a `DO $$ DECLARE ... FOREACH ... DISABLE ROW LEVEL SECURITY` loop plus `GRANT UPDATE, DELETE, INSERT ON "audit_events" TO sep_app` to reverse the REVOKE. Disabling (not dropping) policies is reversible by re-enabling, per plan §7.4.
- **init.sql change (T01):** `ALTER ROLE sep WITH BYPASSRLS` and `ALTER ROLE sep_app WITH NOBYPASSRLS NOSUPERUSER` are idempotent. Running `ALTER ROLE ... WITH NOBYPASSRLS` explicitly reverses them. Existing dev DBs need `docker compose down -v && up -d` to re-init, *or* the two ALTER statements run manually — this is documented in the T01 commit message.
- **Compensating controls if not rollback-safe:** none — all changes are safely reversible at the DB layer.

## Known regression

All audit write paths fail with `permission denied for table audit_events` between this PR merging and M3.A2 landing `GRANT INSERT`. Affects: `AuditService.record()` anywhere it runs, service-level integration tests that write audit events, operator-console workflows that trigger audit writes. Production is not yet deployed, so no customer impact. Dev and integration test cycles need to either run with M3.A2 also applied, or be prepared to see audit-write errors until M3.A2.

## Verify output

```
$ node _plan/scripts/verify-m3-0-findings.mjs
25 passed (8 with notes), 0 failed, 0 blocked (M3.A0 scope), 25 total
All M3.0 closures mechanically verified. Safe to proceed with M3 execution.
```

## Closures

Partially closes PRIOR-R2-001 and PRIOR-R3-001 — DB-layer tenant isolation.
Full closure requires PR #2 (runtime injection) + PR #3 (negative test suite).

## Follow-up issues filed during execution

- #21 — build pipeline stale tsbuildinfo (filed in session 1, unchanged)
- #22 — schema drift on `crypto_operation_records` (filed during T02 when `prisma migrate dev --create-only` flagged unrelated `TIMESTAMPTZ` vs `TIMESTAMP(3)` divergence; T02/T03/T04 migrations were hand-written to bypass)
- #24 — vacuous Contract/Integration CI jobs (filed during PR #23 fix-up verification; 2 of 8 CI checks report green without running assertions)
- #25 — Claude Code CI monitor loop pattern note (filed for next-session continuity)
- #26 — M3.A2 audit_events SELECT scoping decision (filed during PR #23 round-3 re-read; tenant_select on audit_events is overshadowed by audit_allow_select; M3.A2 to choose AS RESTRICTIVE or drop audit_allow_select)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)