### PR TITLE
fix(rls): drop OR-defeating permissive policies on crypto_operation_records

### DIFF
--- a/packages/db/prisma/migrations/20260419070937_drop_crypto_ops_or_defeat_policies/migration.sql
+++ b/packages/db/prisma/migrations/20260419070937_drop_crypto_ops_or_defeat_policies/migration.sql
@@ -1,0 +1,38 @@
+-- Drop OR-defeating permissive policies on crypto_operation_records.
+--
+-- The tenant_* policies from M3.A1-T04 (migration
+-- 20260418222953_enable_rls_tenant_tables) provide correct tenant-scoped
+-- RLS. The _allow_* policies dropped below were M2 baseline scaffolding
+-- (from migration 20260413100000_add_crypto_operation_records) that
+-- OR-defeats tenant isolation:
+--
+--   crypto_operation_records_allow_select USING (true)
+--     OR-combines with tenant_select → SELECT returns ALL rows regardless
+--     of app.current_tenant_id. sep_app can read across tenants.
+--
+--   crypto_operation_records_allow_insert WITH CHECK (true)
+--     OR-combines with tenant_insert → INSERT accepts ANY tenantId
+--     regardless of app.current_tenant_id. sep_app can write rows
+--     attributed to other tenants.
+--
+-- This is the same class of bug that PR #23 (M3.A1-T04) round-3 re-read
+-- caught for audit_events. PR #23 fixed audit_events via REVOKE at the
+-- grant layer; it should have also swept the rest of the schema for the
+-- same pattern. Only crypto_operation_records has it — audited during
+-- M3.A1-T06 execution. See issue #28 for full analysis.
+--
+-- The deny_update / deny_delete policies remain. They are USING (false)
+-- and only OR-combine to grant access when paired with a permissive
+-- policy that returns true. tenant_update / tenant_delete return true
+-- only when tenantId matches app.current_tenant_id, so the OR result
+-- correctly enforces tenant isolation. M3.A2 may sweep these as part of
+-- the broader audit_events deny-all cleanup, but they are harmless now.
+--
+-- Rollback: re-create the dropped policies. Down migration not wired
+-- (prisma convention; manual SQL if true rollback ever needed).
+
+DROP POLICY IF EXISTS "crypto_operation_records_allow_insert"
+  ON "crypto_operation_records";
+
+DROP POLICY IF EXISTS "crypto_operation_records_allow_select"
+  ON "crypto_operation_records";


### PR DESCRIPTION
Closes #28.

## Problem

Migration `20260413100000_add_crypto_operation_records` (M2-era) created four RLS policies on `crypto_operation_records`:

```
crypto_operation_records_allow_insert  WITH CHECK (true)
crypto_operation_records_allow_select  USING (true)
crypto_operation_records_deny_update   USING (false)
crypto_operation_records_deny_delete   USING (false)
```

After M3.A1-T04 (PR #23) added `tenant_insert/select/update/delete` policies, the two `_allow_*` policies OR-combine with the new tenant policies and silently defeat tenant isolation:

- **SELECT:** `allow_select` (true) OR `tenant_select` (tenantId=ctx) = true → `sep_app` sees rows from every tenant.
- **INSERT:** `allow_insert` WITH CHECK (true) OR `tenant_insert` (tenantId=ctx) = true → `sep_app` can insert with any `tenantId` regardless of session context.

UPDATE and DELETE correctly fail closed because `deny_update`/`deny_delete` are USING (false) — OR with `tenant_update`/`tenant_delete` produces the expected tenant-scoped behavior.

This is the same class of bug that PR #23 (M3.A1 PR #1) round-3 re-read caught for `audit_events`. PR #23 fixed `audit_events` via REVOKE; it should have also swept the rest of the schema for the same pattern. Surfaced now during M3.A1-T06 negative-test execution; audit of the other 16 tenant-scoped tables found no further divergence.

## Fix

Drop `crypto_operation_records_allow_insert` and `crypto_operation_records_allow_select`. The `tenant_insert` and `tenant_select` from T04 then enforce correct tenant isolation. The two `deny_*` policies remain (harmless under OR with the tenant predicates; M3.A2 may sweep them as part of the broader baseline cleanup).

## Self-review (§10.1 option ii)

### Threat model considered

- **Attack surface:** `sep_app` runtime role on `crypto_operation_records` table — a tenant-scoped immutable audit trail for crypto operations. Crosses tenant boundary in two directions before the fix: read leakage (other tenants' crypto-op metadata visible) and write attribution (rows can be inserted with arbitrary `tenantId`).
- **OWASP category:** A01:2021 Broken Access Control (cross-tenant authorization bypass).
- **CWE:** CWE-284 (Improper Access Control) — same class as PR #23's audit_events finding.

### Test coverage added

- Manual spot-checks against local docker compose Postgres after the migration applies:
  1. As `sep_app` with no tenant context: `cryptoOperationRecord.count()` returned 0 (was returning all rows pre-fix).
  2. As `sep_app` inside `forTenant(TENANT_A)` attempting INSERT with `tenantId=TENANT_B`: WITH CHECK rejected the row (was accepting it pre-fix).
- The full 8-assertion negative test for `crypto_operation_records` will land in M3.A1 PR #3 (T06) — currently blocked on this fix per stop-and-report discipline. Once this PR merges, T06 picks up `crypto_operation_records` as a normal helper-driven test like the other 15 standard tables (audit_events stays handwritten because of its time-boxed M3.A2 divergence).
- Existing 14/14 unit tests pass post-migration; M3.0 verification script remains 25/0/0.

### Rollback path documented

- **Forward rollback:** re-create the two dropped policies via direct SQL on a hot system (cheap; no data movement). Down migration not wired (Prisma convention).
- **Migration revert:** `prisma migrate resolve --rolled-back 20260419070937_drop_crypto_ops_or_defeat_policies` then manually `CREATE POLICY` the two dropped policies. Documented in this PR's commit message.
- **Compensating control if rollback needed in production:** the application must enforce tenant isolation in code paths that touch `crypto_operation_records` until the policies are restored. Currently no production deployment exists, so this risk is theoretical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)