### PR TITLE
test(m3.a1-t06): cross-tenant RLS negative test suite (144 assertions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,58 @@ jobs:
       - run: pnpm test:e2e
 
   # ─────────────────────────────────────────────────────────
+  # Stage 7b: RLS negative tests (cross-tenant isolation)
+  # ─────────────────────────────────────────────────────────
+  # Plan §5-T06 / §9 calls for these as a required check. Mirrors the
+  # integration-tests job's services + env-var contract; runs the
+  # 144-assertion cross-tenant suite via @sep/rls-negative-tests.
+  rls-negative-tests:
+    name: RLS negative tests
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs: build
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: sep_test
+          POSTGRES_USER: sep
+          POSTGRES_PASSWORD: sep
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://sep:sep@localhost:5432/sep_test
+      RUNTIME_DATABASE_URL: postgresql://sep_app:sep_app@localhost:5432/sep_test
+      NODE_ENV: test
+      APP_ENV: ci
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: build-artifacts
+      - name: Run DB migrations
+        # Migrations create the sep_app runtime role (M3.A1-T01) and apply
+        # all RLS policies the suite verifies. Must run before the suite.
+        run: pnpm --filter @sep/db exec prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+      - run: pnpm --filter @sep/rls-negative-tests test:integration
+
+  # ─────────────────────────────────────────────────────────
   # Stage 8: Security scans
   # ─────────────────────────────────────────────────────────
   security:

--- a/_plan/M3_A1_EXECUTION_PROMPT.md
+++ b/_plan/M3_A1_EXECUTION_PROMPT.md
@@ -222,6 +222,8 @@ Before writing any RLS policy or SET LOCAL call, internalize this list. If you f
 
 10. **Policy naming.** Plan pattern is `<table>_tenant_<op>` (e.g., `users_tenant_select`). Postgres scopes policy names per-table, so two tables can both have `<t>_tenant_select` without collision. Stick to the plan pattern; don't deviate.
 
+11. **OR-defeat by pre-existing permissive policies.** Postgres combines permissive policies with OR. A pre-existing `<table>_allow_select` USING (true) (or `_allow_insert` WITH CHECK (true)) from an earlier migration will OR-combine with a new `<table>_tenant_select` and silently defeat tenant isolation — the OR result is `true OR <tenant predicate>` = `true`. When adding RLS to a table, audit the full current policy list on that table (`SELECT polname, polcmd FROM pg_policy p JOIN pg_class c ON p.polrelid = c.oid WHERE c.relname = '<t>'`) and ensure no `USING (true)` or `WITH CHECK (true)` policies exist that would OR-combine to defeat tenant isolation. Fix either by dropping the permissive policies or by REVOKE at the grant layer if the writes should remain privileged. PR #23's round-3 re-read caught this for `audit_events`; M3.A1-T06 surfaced the same gap on `crypto_operation_records` (issue #28, fixed in PR #29). `_deny_*` policies USING (false) are safe — `false OR <x>` = `<x>`, so they don't OR-defeat anything; they're inert when a tenant policy is present.
+
 ## 8. Self-review mechanics — option (ii)
 
 **When to write the self-review block:** at PR creation, not at merge time. The block goes in the PR body.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,43 @@ importers:
         specifier: 3.2.4
         version: 3.2.4(@types/node@20.19.39)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(terser@5.46.1)
 
+  tests/integration/rls-negative-tests:
+    dependencies:
+      '@prisma/client':
+        specifier: 5.22.0
+        version: 5.22.0(prisma@5.22.0)
+      '@sep/common':
+        specifier: workspace:*
+        version: link:../../../packages/common
+      '@sep/db':
+        specifier: workspace:*
+        version: link:../../../packages/db
+      '@sep/schemas':
+        specifier: workspace:*
+        version: link:../../../packages/schemas
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.39
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.0.0
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.0.0
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.2(eslint@8.57.1)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/node@20.19.39)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(terser@5.46.1)
+
 packages:
   '@alloc/quick-lru@5.2.0':
     resolution:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+  - 'tests/integration/*'

--- a/tests/integration/rls-negative-tests/.eslintrc.js
+++ b/tests/integration/rls-negative-tests/.eslintrc.js
@@ -16,6 +16,11 @@ module.exports = {
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',
+        // Per-table parent-id maps populated in setupParents are read by
+        // seedRow/validInsertPayload — Record<string, string> indexing
+        // gives string|undefined under noUncheckedIndexedAccess, but the
+        // value is guaranteed populated by setupParents ordering.
+        '@typescript-eslint/no-non-null-assertion': 'off',
       },
     },
   ],

--- a/tests/integration/rls-negative-tests/.eslintrc.js
+++ b/tests/integration/rls-negative-tests/.eslintrc.js
@@ -1,0 +1,22 @@
+module.exports = {
+  extends: ['../../../.eslintrc.base.js'],
+  parserOptions: { project: './tsconfig.json' },
+  overrides: [
+    {
+      // Helper modules sit alongside test files and exist solely to support
+      // them. Same relaxations the base config grants *.test.ts: process.env
+      // is the integration gate, and the cross-table helper indexes Prisma
+      // model accessors dynamically (any/unsafe-* are unavoidable there).
+      files: ['_helpers/**/*.ts', '**/*.test.ts'],
+      rules: {
+        'no-process-env': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-unsafe-assignment': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
+        '@typescript-eslint/no-unsafe-call': 'off',
+        '@typescript-eslint/no-unsafe-return': 'off',
+        '@typescript-eslint/no-unsafe-argument': 'off',
+      },
+    },
+  ],
+};

--- a/tests/integration/rls-negative-tests/_helpers/clients.ts
+++ b/tests/integration/rls-negative-tests/_helpers/clients.ts
@@ -1,0 +1,69 @@
+// Shared test-fixture infrastructure for the M3.A1-T06 negative suite.
+//
+// Two PrismaClient instances per test file:
+//   - seedClient connects as the migration role (sep) which has BYPASSRLS.
+//     Used to set up cross-tenant data the runtime must NOT be able to see.
+//   - runtimeClient connects as the application role (sep_app) which has
+//     BYPASSRLS=false and is the role every RLS policy applies to. This is
+//     the role under test.
+//
+// The DatabaseService wraps runtimeClient and exposes forTenant() — that is
+// the path runtime callers use, so it is what we exercise.
+//
+// Tenants are upserted (idempotent) by ensureTestTenants() and deliberately
+// NOT torn down. Per-table cleanup removes only the rows each table seeded.
+
+import { PrismaClient } from '@prisma/client';
+import { DatabaseService } from '@sep/db';
+
+// eslint-disable-next-line no-process-env -- integration gate reads env directly
+export const MIGRATION_URL: string | undefined = process.env['DATABASE_URL'];
+// eslint-disable-next-line no-process-env -- integration gate reads env directly
+export const RUNTIME_URL: string | undefined = process.env['RUNTIME_DATABASE_URL'];
+
+export const hasIntegrationEnv: boolean =
+  MIGRATION_URL !== undefined &&
+  MIGRATION_URL.length > 0 &&
+  RUNTIME_URL !== undefined &&
+  RUNTIME_URL.length > 0;
+
+// Fixed cuids matching the schema validator (leading 'c' + lowercase
+// alphanumerics). Two distinct tenants whose isolation is the property
+// under test.
+export const TENANT_A_ID = 'cnegativetenanta1234567890';
+export const TENANT_B_ID = 'cnegativetenantb1234567890';
+
+export function makeSeedClient(): PrismaClient {
+  return new PrismaClient({
+    ...(MIGRATION_URL !== undefined && { datasourceUrl: MIGRATION_URL }),
+  });
+}
+
+export function makeRuntimeClient(): PrismaClient {
+  return new PrismaClient({
+    ...(RUNTIME_URL !== undefined && { datasourceUrl: RUNTIME_URL }),
+  });
+}
+
+export function makeDb(runtimeClient: PrismaClient): DatabaseService {
+  return new DatabaseService(runtimeClient);
+}
+
+/**
+ * Idempotent tenant setup. Safe to call from multiple test files in
+ * parallel — upsert collapses duplicate creates. Deliberately does NOT
+ * tear down: tenants persist across the suite so concurrent files do not
+ * race on each other's teardown.
+ */
+export async function ensureTestTenants(seedClient: PrismaClient): Promise<void> {
+  await seedClient.tenant.upsert({
+    where: { id: TENANT_A_ID },
+    update: {},
+    create: { id: TENANT_A_ID, name: 'RLS-Neg Tenant A', legalEntityName: 'RLS-Neg Tenant A LLC' },
+  });
+  await seedClient.tenant.upsert({
+    where: { id: TENANT_B_ID },
+    update: {},
+    create: { id: TENANT_B_ID, name: 'RLS-Neg Tenant B', legalEntityName: 'RLS-Neg Tenant B LLC' },
+  });
+}

--- a/tests/integration/rls-negative-tests/_helpers/rls-assertions.ts
+++ b/tests/integration/rls-negative-tests/_helpers/rls-assertions.ts
@@ -1,0 +1,207 @@
+// Per-table 8-assertion factory for the M3.A1-T06 negative suite.
+//
+// Plan §5-T06 requires 18 tables × 8 assertions = 144 total cross-tenant
+// negative assertions. Hand-writing 144 near-duplicate test bodies would
+// invite drift, so the 17 standard tenant-scoped tables go through this
+// helper. (audit_events diverges by design — see audit_events.rls-negative
+// .test.ts for that file's handwritten 8 assertions and the M3.A2 TODOs.)
+//
+// The 8 assertions, paired with the cross-tenant property each proves:
+//
+//   Without tenant context (runtime client used directly, no forTenant):
+//     1. SELECT returns 0 rows         — RLS USING fails-closed without GUC
+//     2. INSERT fails                  — WITH CHECK rejects (NULLIF → NULL)
+//     3. UPDATE affects 0 rows         — USING hides every row from update
+//     4. DELETE affects 0 rows         — USING hides every row from delete
+//
+//   With tenant-A context, looking at tenant-B rows:
+//     5. SELECT returns 0 tenant-B rows — USING limits visibility to A
+//     6. INSERT with tenantId=B fails   — WITH CHECK rejects cross-tenant
+//                                          insert (covers gotcha #7 — UPDATE
+//                                          variant covered in #7 below)
+//     7. UPDATE on tenant-B row 0 rows  — USING + WITH CHECK both protect
+//     8. DELETE on tenant-B row 0 rows  — USING protects
+//
+// The runtime role is sep_app (BYPASSRLS=false). The seed role is sep
+// (BYPASSRLS=true) so cross-tenant data exists for assertions 5/7/8 to
+// have something to NOT see.
+
+import { PrismaClient } from '@prisma/client';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { DatabaseService } from '@sep/db';
+
+import {
+  ensureTestTenants,
+  hasIntegrationEnv,
+  makeDb,
+  makeRuntimeClient,
+  makeSeedClient,
+  TENANT_A_ID,
+  TENANT_B_ID,
+} from './clients';
+
+export interface RlsAssertionConfig {
+  /** Display label and SQL identifier (e.g., 'users'). */
+  tableName: string;
+  /**
+   * Prisma client model accessor key (e.g., 'user', 'roleAssignment').
+   * Indexed dynamically inside the helper; the per-table file owns
+   * type-correctness via the seed/payload callbacks below.
+   */
+  modelKey: string;
+  /**
+   * Optional setup for parent rows (partner_profile, submission, etc.)
+   * required by FKs on the table under test. Runs once per file before
+   * seedRow. Use seedClient (BYPASSRLS) so parent rows are unaffected
+   * by RLS during setup.
+   */
+  setupParents?: (seedClient: PrismaClient) => Promise<void>;
+  /**
+   * Create one row in the given tenant. Returns the seeded row's id so
+   * cross-tenant assertions (5/7/8) can target it by primary key. The
+   * seed runs twice — once for tenant A, once for tenant B.
+   */
+  seedRow: (seedClient: PrismaClient, tenantId: string) => Promise<{ id: string }>;
+  /**
+   * A valid INSERT payload for the given tenant — must satisfy NOT NULL,
+   * unique, and FK constraints other than the RLS predicate. Used by
+   * assertions 2 and 6.
+   */
+  validInsertPayload: (tenantId: string) => Record<string, unknown>;
+  /**
+   * Partial UPDATE payload that touches at least one non-tenant column.
+   * Used by assertions 3 and 7. MUST NOT modify tenantId (that would
+   * confound the test by exercising a different leakage class).
+   */
+  validUpdatePayload: () => Record<string, unknown>;
+  /**
+   * Per-file row teardown. Removes seeded rows + parent rows. Tenants
+   * are NOT cleaned up here — see clients.ts for why.
+   */
+  cleanup: (seedClient: PrismaClient) => Promise<void>;
+}
+
+type ModelDelegate = {
+  create: (args: { data: unknown }) => Promise<{ id: string } & Record<string, unknown>>;
+  findMany: (args?: { where?: unknown }) => Promise<Array<Record<string, unknown>>>;
+  updateMany: (args: { where: unknown; data: unknown }) => Promise<{ count: number }>;
+  deleteMany: (args: { where: unknown }) => Promise<{ count: number }>;
+};
+
+function model(client: PrismaClient | { [k: string]: unknown }, key: string): ModelDelegate {
+  const delegate = (client as unknown as Record<string, unknown>)[key];
+  if (delegate === undefined || delegate === null) {
+    throw new Error(
+      `PrismaClient has no model accessor '${key}' — check modelKey in helper config`,
+    );
+  }
+  return delegate as ModelDelegate;
+}
+
+export function assertsRlsOnTable(config: RlsAssertionConfig): void {
+  describe.skipIf(!hasIntegrationEnv)(`RLS negative — ${config.tableName}`, () => {
+    let seedClient: PrismaClient;
+    let runtimeClient: PrismaClient;
+    let db: DatabaseService;
+    let seededARowId: string;
+    let seededBRowId: string;
+
+    beforeAll(async () => {
+      seedClient = makeSeedClient();
+      runtimeClient = makeRuntimeClient();
+      db = makeDb(runtimeClient);
+
+      await ensureTestTenants(seedClient);
+      if (config.setupParents !== undefined) {
+        await config.setupParents(seedClient);
+      }
+
+      const seededA = await config.seedRow(seedClient, TENANT_A_ID);
+      const seededB = await config.seedRow(seedClient, TENANT_B_ID);
+      seededARowId = seededA.id;
+      seededBRowId = seededB.id;
+    });
+
+    afterAll(async () => {
+      await config.cleanup(seedClient);
+      await seedClient.$disconnect();
+      await runtimeClient.$disconnect();
+    });
+
+    // ── Without tenant context ────────────────────────────────────────────
+
+    it(`${config.tableName}: SELECT without tenant context returns 0 rows`, async () => {
+      const rows = await model(runtimeClient, config.modelKey).findMany();
+      expect(rows.length).toBe(0);
+    });
+
+    it(`${config.tableName}: INSERT without tenant context fails`, async () => {
+      // Runtime client outside any forTenant() — the GUC is unset, NULLIF
+      // returns NULL, WITH CHECK predicate evaluates NULL → row rejected.
+      // Postgres throws; Prisma surfaces a known-error wrapping it.
+      await expect(
+        model(runtimeClient, config.modelKey).create({
+          data: config.validInsertPayload(TENANT_A_ID),
+        }),
+      ).rejects.toThrow();
+    });
+
+    it(`${config.tableName}: UPDATE without tenant context affects 0 rows`, async () => {
+      // updateMany returns count of affected rows. Without GUC, USING
+      // hides every row from the runtime — count must be 0 even though
+      // the seeded row exists in the table (sep can see it).
+      const result = await model(runtimeClient, config.modelKey).updateMany({
+        where: { id: seededARowId },
+        data: config.validUpdatePayload(),
+      });
+      expect(result.count).toBe(0);
+    });
+
+    it(`${config.tableName}: DELETE without tenant context affects 0 rows`, async () => {
+      const result = await model(runtimeClient, config.modelKey).deleteMany({
+        where: { id: seededARowId },
+      });
+      expect(result.count).toBe(0);
+    });
+
+    // ── With tenant-A context, targeting tenant-B rows ────────────────────
+
+    it(`${config.tableName}: SELECT in tenant-A context does not see tenant-B rows`, async () => {
+      const rows = await db.forTenant(TENANT_A_ID, async (tx) =>
+        model(tx, config.modelKey).findMany({ where: { id: seededBRowId } }),
+      );
+      expect(rows.length).toBe(0);
+    });
+
+    it(`${config.tableName}: INSERT in tenant-A context with tenantId=B fails WITH CHECK`, async () => {
+      // GUC = TENANT_A_ID, payload tenantId = TENANT_B_ID. WITH CHECK
+      // predicate evaluates `'cnegativetenantb...' = 'cnegativetenanta...'`
+      // → false → row rejected.
+      await expect(
+        db.forTenant(TENANT_A_ID, async (tx) =>
+          model(tx, config.modelKey).create({
+            data: config.validInsertPayload(TENANT_B_ID),
+          }),
+        ),
+      ).rejects.toThrow();
+    });
+
+    it(`${config.tableName}: UPDATE in tenant-A context on tenant-B row affects 0 rows`, async () => {
+      const result = await db.forTenant(TENANT_A_ID, async (tx) =>
+        model(tx, config.modelKey).updateMany({
+          where: { id: seededBRowId },
+          data: config.validUpdatePayload(),
+        }),
+      );
+      expect(result.count).toBe(0);
+    });
+
+    it(`${config.tableName}: DELETE in tenant-A context on tenant-B row affects 0 rows`, async () => {
+      const result = await db.forTenant(TENANT_A_ID, async (tx) =>
+        model(tx, config.modelKey).deleteMany({ where: { id: seededBRowId } }),
+      );
+      expect(result.count).toBe(0);
+    });
+  });
+}

--- a/tests/integration/rls-negative-tests/api-keys.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/api-keys.rls-negative.test.ts
@@ -1,0 +1,36 @@
+// M3.A1-T06: RLS negative assertions for `api_keys`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+assertsRlsOnTable({
+  tableName: 'api_keys',
+  modelKey: 'apiKey',
+  seedRow: (seedClient, tenantId) =>
+    seedClient.apiKey.create({
+      data: {
+        tenantId,
+        name: `seed-apikey-${tenantId}`,
+        // keyHash is unique across rows — disambiguate per tenant.
+        keyHash: `seed-hash-${tenantId}-${Date.now()}-${Math.random()}`,
+        prefix: `sk_seed_${tenantId.slice(-4)}`,
+        role: 'INTEGRATION_ENGINEER',
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    name: `insert-apikey-${tenantId}-${Date.now()}`,
+    keyHash: `insert-hash-${tenantId}-${Date.now()}-${Math.random()}`,
+    prefix: `sk_ins_${tenantId.slice(-4)}`,
+    role: 'INTEGRATION_ENGINEER',
+  }),
+  validUpdatePayload: () => ({ revocationReason: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.apiKey.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        name: { contains: 'apikey' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/approvals.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/approvals.rls-negative.test.ts
@@ -1,0 +1,55 @@
+// M3.A1-T06: RLS negative assertions for `approvals`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+const tenantInitiatorId: Record<string, string> = {};
+
+assertsRlsOnTable({
+  tableName: 'approvals',
+  modelKey: 'approval',
+  setupParents: async (seedClient) => {
+    for (const tenantId of [TENANT_A_ID, TENANT_B_ID]) {
+      const user = await seedClient.user.create({
+        data: {
+          tenantId,
+          email: `approval-initiator-${tenantId}@rls-negative.test`,
+          displayName: `Approval initiator for ${tenantId}`,
+        },
+      });
+      tenantInitiatorId[tenantId] = user.id;
+    }
+  },
+  seedRow: (seedClient, tenantId) =>
+    seedClient.approval.create({
+      data: {
+        tenantId,
+        action: 'PARTNER_PROFILE_ACTIVATE',
+        objectType: 'PartnerProfile',
+        objectId: `seed-target-${tenantId}`,
+        initiatorId: tenantInitiatorId[tenantId]!,
+        // 7 days from now — well outside the assertion window.
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    action: 'KEY_ACTIVATE',
+    objectType: 'KeyReference',
+    objectId: `insert-target-${tenantId}-${Date.now()}`,
+    initiatorId: tenantInitiatorId[tenantId]!,
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  }),
+  validUpdatePayload: () => ({ notes: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.approval.deleteMany({
+      where: { tenantId: { in: [TENANT_A_ID, TENANT_B_ID] } },
+    });
+    await seedClient.user.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        email: { contains: 'approval-initiator' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/audit-events.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/audit-events.rls-negative.test.ts
@@ -1,0 +1,199 @@
+// M3.A1-T06: RLS negative assertions for `audit_events` (handwritten).
+//
+// audit_events diverges from the helper's standard 8-assertion pattern in
+// two ways and is therefore handwritten rather than parametrized:
+//
+// (1) Writes (INSERT/UPDATE/DELETE) are blocked at the GRANT layer by the
+//     REVOKE landed in PR #23 (M3.A1-T04 migration
+//     20260418222953_enable_rls_tenant_tables — bottom of the file). The
+//     REVOKE strips UPDATE/DELETE/INSERT from sep_app, so all 6 write
+//     attempts in the standard pattern raise "permission denied for table
+//     audit_events" rather than failing via RLS predicate. The error class
+//     is correct (writes are prevented from the runtime role) but the
+//     mechanism differs from the other 17 tables — a class change worth
+//     making explicit instead of hiding behind a helper discriminator.
+//
+// (2) SELECT is NOT blocked by REVOKE (sep_app retains SELECT) and the
+//     baseline `audit_allow_select` policy USING (true) OR-wins against
+//     the M3.A1-T04 `audit_events_tenant_select` policy. Cross-tenant
+//     SELECT is currently visible — same RLS gap PR #23 round-3 re-read
+//     surfaced. Two assertions in this file therefore document the
+//     CURRENT permissive behavior rather than the desired tenant-isolated
+//     behavior. They will flip to .toBe(0) in M3.A2 when audit_allow_select
+//     is dropped (and AuditService writes via parent transaction
+//     re-acquire INSERT via a controlled GRANT).
+//
+// TODO(M3.A2): when audit_allow_select is dropped and tenant_select
+// becomes the only SELECT policy on audit_events, flip these two
+// assertions from .toBeGreaterThan(0) to .toBe(0). See PR #23 round-3
+// re-read finding and issue #26.
+
+import { PrismaClient } from '@prisma/client';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  ensureTestTenants,
+  hasIntegrationEnv,
+  makeDb,
+  makeRuntimeClient,
+  makeSeedClient,
+  TENANT_A_ID,
+  TENANT_B_ID,
+} from './_helpers/clients';
+import { DatabaseService } from '@sep/db';
+
+describe.skipIf(!hasIntegrationEnv)('RLS negative — audit_events', () => {
+  let seedClient: PrismaClient;
+  let runtimeClient: PrismaClient;
+  let db: DatabaseService;
+  let seededARowId: string;
+  let seededBRowId: string;
+
+  beforeAll(async () => {
+    seedClient = makeSeedClient();
+    runtimeClient = makeRuntimeClient();
+    db = makeDb(runtimeClient);
+
+    await ensureTestTenants(seedClient);
+
+    // Seed via sep (BYPASSRLS) — sep_app's grant-layer REVOKE prevents
+    // it from doing this directly. The seeded rows feed the SELECT-
+    // divergence assertions and the targeted-row write assertions.
+    const seededA = await seedClient.auditEvent.create({
+      data: {
+        tenantId: TENANT_A_ID,
+        actorType: 'SYSTEM',
+        actorId: 'rls-negative-test',
+        objectType: 'TestObject',
+        objectId: 'seed-a',
+        action: 'TENANT_CREATED',
+        result: 'SUCCESS',
+        immutableHash: `audit-seed-a-${Date.now()}`,
+      },
+    });
+    const seededB = await seedClient.auditEvent.create({
+      data: {
+        tenantId: TENANT_B_ID,
+        actorType: 'SYSTEM',
+        actorId: 'rls-negative-test',
+        objectType: 'TestObject',
+        objectId: 'seed-b',
+        action: 'TENANT_CREATED',
+        result: 'SUCCESS',
+        immutableHash: `audit-seed-b-${Date.now()}`,
+      },
+    });
+    seededARowId = seededA.id;
+    seededBRowId = seededB.id;
+  });
+
+  afterAll(async () => {
+    // No cleanup of audit_events — the M3.0 audit_deny_delete policy
+    // (USING false) blocks DELETE for every role, BYPASSRLS or not. Rows
+    // accumulate across local reruns; CI starts from a fresh DB, so this
+    // is dev-only. Unlike crypto_operation_records, the deny here is via
+    // RLS policy rather than a trigger, but the practical effect is the
+    // same: the seed row is permanent.
+    await seedClient.$disconnect();
+    await runtimeClient.$disconnect();
+  });
+
+  // ── Without tenant context ──────────────────────────────────────────────
+
+  it('audit_events: SELECT without tenant context returns rows (DIVERGENT)', async () => {
+    // TODO(M3.A2): when audit_allow_select is dropped and tenant_select
+    // becomes the only SELECT policy on audit_events, flip this from
+    // .toBeGreaterThan(0) to .toBe(0). See PR #23 round-3 re-read finding
+    // and issue #26.
+    const rows = await runtimeClient.auditEvent.findMany();
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('audit_events: INSERT without tenant context fails (grant-layer REVOKE)', async () => {
+    // sep_app has no INSERT grant on audit_events after PR #23's REVOKE.
+    // This raises "permission denied for table audit_events" — different
+    // class from the WITH CHECK rejection on the other 17 tables but a
+    // stronger guarantee (RLS-bypassable roles cannot circumvent it
+    // without re-granting at the role level).
+    await expect(
+      runtimeClient.auditEvent.create({
+        data: {
+          tenantId: TENANT_A_ID,
+          actorType: 'SYSTEM',
+          actorId: 'probe',
+          objectType: 'Probe',
+          objectId: 'probe',
+          action: 'TENANT_CREATED',
+          result: 'SUCCESS',
+          immutableHash: `probe-${Date.now()}`,
+        },
+      }),
+    ).rejects.toThrow(/permission denied/i);
+  });
+
+  it('audit_events: UPDATE without tenant context fails (grant-layer REVOKE)', async () => {
+    await expect(
+      runtimeClient.auditEvent.updateMany({
+        where: { id: seededARowId },
+        data: { result: 'updated-by-rls-negative' },
+      }),
+    ).rejects.toThrow(/permission denied/i);
+  });
+
+  it('audit_events: DELETE without tenant context fails (grant-layer REVOKE)', async () => {
+    await expect(
+      runtimeClient.auditEvent.deleteMany({ where: { id: seededARowId } }),
+    ).rejects.toThrow(/permission denied/i);
+  });
+
+  // ── With tenant-A context, targeting tenant-B rows ──────────────────────
+
+  it('audit_events: SELECT in tenant-A context still sees tenant-B rows (DIVERGENT)', async () => {
+    // TODO(M3.A2): when audit_allow_select is dropped and tenant_select
+    // becomes the only SELECT policy on audit_events, flip this from
+    // .toBeGreaterThan(0) to .toBe(0). See PR #23 round-3 re-read finding
+    // and issue #26.
+    const rows = await db.forTenant(TENANT_A_ID, async (tx) =>
+      tx.auditEvent.findMany({ where: { id: seededBRowId } }),
+    );
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('audit_events: INSERT in tenant-A context with tenantId=B fails (grant-layer REVOKE)', async () => {
+    await expect(
+      db.forTenant(TENANT_A_ID, async (tx) =>
+        tx.auditEvent.create({
+          data: {
+            tenantId: TENANT_B_ID,
+            actorType: 'SYSTEM',
+            actorId: 'probe',
+            objectType: 'Probe',
+            objectId: 'probe',
+            action: 'TENANT_CREATED',
+            result: 'SUCCESS',
+            immutableHash: `probe-${Date.now()}`,
+          },
+        }),
+      ),
+    ).rejects.toThrow(/permission denied/i);
+  });
+
+  it('audit_events: UPDATE in tenant-A context on tenant-B row fails (grant-layer REVOKE)', async () => {
+    await expect(
+      db.forTenant(TENANT_A_ID, async (tx) =>
+        tx.auditEvent.updateMany({
+          where: { id: seededBRowId },
+          data: { result: 'updated-by-rls-negative' },
+        }),
+      ),
+    ).rejects.toThrow(/permission denied/i);
+  });
+
+  it('audit_events: DELETE in tenant-A context on tenant-B row fails (grant-layer REVOKE)', async () => {
+    await expect(
+      db.forTenant(TENANT_A_ID, async (tx) =>
+        tx.auditEvent.deleteMany({ where: { id: seededBRowId } }),
+      ),
+    ).rejects.toThrow(/permission denied/i);
+  });
+});

--- a/tests/integration/rls-negative-tests/crypto-operation-records.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/crypto-operation-records.rls-negative.test.ts
@@ -1,0 +1,61 @@
+// M3.A1-T06: RLS negative assertions for `crypto_operation_records`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+const tenantKeyReferenceId: Record<string, string> = {};
+
+assertsRlsOnTable({
+  tableName: 'crypto_operation_records',
+  modelKey: 'cryptoOperationRecord',
+  setupParents: async (seedClient) => {
+    for (const tenantId of [TENANT_A_ID, TENANT_B_ID]) {
+      const keyRef = await seedClient.keyReference.create({
+        data: {
+          tenantId,
+          name: `crypto-parent-${tenantId}`,
+          usage: ['SIGN'],
+          backendType: 'PLATFORM_VAULT',
+          backendRef: `vault://crypto-parent/${tenantId}`,
+          fingerprint: `crypto-parent-fp-${tenantId}`,
+          algorithm: 'RSA-2048',
+          environment: 'TEST',
+        },
+      });
+      tenantKeyReferenceId[tenantId] = keyRef.id;
+    }
+  },
+  seedRow: (seedClient, tenantId) =>
+    seedClient.cryptoOperationRecord.create({
+      data: {
+        tenantId,
+        keyReferenceId: tenantKeyReferenceId[tenantId]!,
+        operationType: 'SIGN',
+        result: 'SUCCESS',
+        algorithmPolicy: { algorithm: 'RSA-2048' },
+        keyFingerprint: `seed-fp-${tenantId}`,
+        performedAt: new Date(),
+        actorId: 'rls-negative-test',
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    keyReferenceId: tenantKeyReferenceId[tenantId]!,
+    operationType: 'SIGN',
+    result: 'SUCCESS',
+    algorithmPolicy: { algorithm: 'RSA-2048' },
+    keyFingerprint: `insert-fp-${tenantId}-${Date.now()}`,
+    performedAt: new Date(),
+    actorId: 'rls-negative-test',
+  }),
+  validUpdatePayload: () => ({ errorCode: 'updated-by-rls-negative' }),
+  // No cleanup — crypto_operation_records carries an immutability trigger
+  // (crypto_operation_records_no_delete) that blocks DELETE for every role,
+  // including the BYPASSRLS sep role. The KeyReference parent cannot be
+  // removed either because its FK is onDelete: Restrict. Both tables
+  // accumulate seed rows across local reruns; CI starts from a fresh DB so
+  // accumulation is dev-only. Assertion correctness is unaffected — the 8
+  // assertions target rows by primary-key id, so prior-run rows do not
+  // confound them.
+  cleanup: () => Promise.resolve(),
+});

--- a/tests/integration/rls-negative-tests/delivery-attempts.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/delivery-attempts.rls-negative.test.ts
@@ -1,0 +1,67 @@
+// M3.A1-T06: RLS negative assertions for `delivery_attempts`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+const tenantPartnerProfileId: Record<string, string> = {};
+const tenantSubmissionId: Record<string, string> = {};
+
+assertsRlsOnTable({
+  tableName: 'delivery_attempts',
+  modelKey: 'deliveryAttempt',
+  setupParents: async (seedClient) => {
+    for (const tenantId of [TENANT_A_ID, TENANT_B_ID]) {
+      const partner = await seedClient.partnerProfile.create({
+        data: {
+          tenantId,
+          name: `delivery-parent-${tenantId}`,
+          partnerType: 'BANK',
+          environment: 'TEST',
+          transportProtocol: 'SFTP',
+          config: {},
+        },
+      });
+      tenantPartnerProfileId[tenantId] = partner.id;
+      const submission = await seedClient.submission.create({
+        data: {
+          tenantId,
+          partnerProfileId: partner.id,
+          idempotencyKey: `delivery-parent-idem-${tenantId}-${Date.now()}`,
+          contentType: 'application/json',
+        },
+      });
+      tenantSubmissionId[tenantId] = submission.id;
+    }
+  },
+  seedRow: (seedClient, tenantId) =>
+    seedClient.deliveryAttempt.create({
+      data: {
+        tenantId,
+        submissionId: tenantSubmissionId[tenantId]!,
+        attemptNo: 1,
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    submissionId: tenantSubmissionId[tenantId]!,
+    attemptNo: 2,
+  }),
+  validUpdatePayload: () => ({ remoteReference: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.deliveryAttempt.deleteMany({
+      where: { tenantId: { in: [TENANT_A_ID, TENANT_B_ID] } },
+    });
+    await seedClient.submission.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        idempotencyKey: { contains: 'delivery-parent-idem' },
+      },
+    });
+    await seedClient.partnerProfile.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        name: { contains: 'delivery-parent' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/exchange-profiles.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/exchange-profiles.rls-negative.test.ts
@@ -1,0 +1,57 @@
+// M3.A1-T06: RLS negative assertions for `exchange_profiles`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+// Per-tenant parent partner_profile id, captured in setupParents.
+const tenantPartnerProfileId: Record<string, string> = {};
+
+assertsRlsOnTable({
+  tableName: 'exchange_profiles',
+  modelKey: 'exchangeProfile',
+  setupParents: async (seedClient) => {
+    for (const tenantId of [TENANT_A_ID, TENANT_B_ID]) {
+      const partner = await seedClient.partnerProfile.create({
+        data: {
+          tenantId,
+          name: `xprofile-parent-${tenantId}`,
+          partnerType: 'BANK',
+          environment: 'TEST',
+          transportProtocol: 'SFTP',
+          config: {},
+        },
+      });
+      tenantPartnerProfileId[tenantId] = partner.id;
+    }
+  },
+  seedRow: (seedClient, tenantId) =>
+    seedClient.exchangeProfile.create({
+      data: {
+        tenantId,
+        name: `seed-xprofile-${tenantId}`,
+        partnerProfileId: tenantPartnerProfileId[tenantId]!,
+        fileTypes: ['CSV'],
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    name: `insert-xprofile-${tenantId}-${Date.now()}`,
+    partnerProfileId: tenantPartnerProfileId[tenantId]!,
+    fileTypes: ['CSV'],
+  }),
+  validUpdatePayload: () => ({ description: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.exchangeProfile.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        name: { contains: 'xprofile' },
+      },
+    });
+    await seedClient.partnerProfile.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        name: { contains: 'xprofile-parent' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/inbound-receipts.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/inbound-receipts.rls-negative.test.ts
@@ -1,0 +1,54 @@
+// M3.A1-T06: RLS negative assertions for `inbound_receipts`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+const tenantPartnerProfileId: Record<string, string> = {};
+
+assertsRlsOnTable({
+  tableName: 'inbound_receipts',
+  modelKey: 'inboundReceipt',
+  setupParents: async (seedClient) => {
+    for (const tenantId of [TENANT_A_ID, TENANT_B_ID]) {
+      const partner = await seedClient.partnerProfile.create({
+        data: {
+          tenantId,
+          name: `inbound-parent-${tenantId}`,
+          partnerType: 'BANK',
+          environment: 'TEST',
+          transportProtocol: 'SFTP',
+          config: {},
+        },
+      });
+      tenantPartnerProfileId[tenantId] = partner.id;
+    }
+  },
+  seedRow: (seedClient, tenantId) =>
+    seedClient.inboundReceipt.create({
+      data: {
+        tenantId,
+        partnerProfileId: tenantPartnerProfileId[tenantId]!,
+        correlationId: `seed-corr-${tenantId}-${Date.now()}`,
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    partnerProfileId: tenantPartnerProfileId[tenantId]!,
+    correlationId: `insert-corr-${tenantId}-${Date.now()}`,
+  }),
+  validUpdatePayload: () => ({ parsedStatus: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.inboundReceipt.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        correlationId: { contains: '-corr-' },
+      },
+    });
+    await seedClient.partnerProfile.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        name: { contains: 'inbound-parent' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/incidents.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/incidents.rls-negative.test.ts
@@ -1,0 +1,33 @@
+// M3.A1-T06: RLS negative assertions for `incidents`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+assertsRlsOnTable({
+  tableName: 'incidents',
+  modelKey: 'incident',
+  seedRow: (seedClient, tenantId) =>
+    seedClient.incident.create({
+      data: {
+        tenantId,
+        severity: 'P3',
+        title: `seed-incident-${tenantId}`,
+        sourceType: 'rls-negative-test',
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    severity: 'P3',
+    title: `insert-incident-${tenantId}-${Date.now()}`,
+    sourceType: 'rls-negative-test',
+  }),
+  validUpdatePayload: () => ({ description: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.incident.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        title: { contains: 'incident' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/key-references.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/key-references.rls-negative.test.ts
@@ -1,0 +1,41 @@
+// M3.A1-T06: RLS negative assertions for `key_references`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+assertsRlsOnTable({
+  tableName: 'key_references',
+  modelKey: 'keyReference',
+  seedRow: (seedClient, tenantId) =>
+    seedClient.keyReference.create({
+      data: {
+        tenantId,
+        name: `seed-key-${tenantId}`,
+        usage: ['SIGN'],
+        backendType: 'PLATFORM_VAULT',
+        backendRef: `vault://rls-neg/seed-${tenantId}`,
+        fingerprint: `seed-fingerprint-${tenantId}`,
+        algorithm: 'RSA-2048',
+        environment: 'TEST',
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    name: `insert-key-${tenantId}-${Date.now()}`,
+    usage: ['SIGN'],
+    backendType: 'PLATFORM_VAULT',
+    backendRef: `vault://rls-neg/insert-${tenantId}-${Date.now()}`,
+    fingerprint: `insert-fingerprint-${tenantId}-${Date.now()}`,
+    algorithm: 'RSA-2048',
+    environment: 'TEST',
+  }),
+  validUpdatePayload: () => ({ algorithm: 'RSA-4096' }),
+  cleanup: async (seedClient) => {
+    await seedClient.keyReference.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        name: { contains: 'key' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/package.json
+++ b/tests/integration/rls-negative-tests/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@sep/rls-negative-tests",
+  "version": "0.1.0",
+  "private": true,
+  "description": "M3.A1-T06 cross-tenant RLS negative test suite (18 tables × 8 assertions = 144).",
+  "scripts": {
+    "test:integration": "vitest run",
+    "lint": "eslint . --ext .ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sep/common": "workspace:*",
+    "@sep/db": "workspace:*",
+    "@sep/schemas": "workspace:*",
+    "@prisma/client": "5.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "5.9.3",
+    "vitest": "3.2.4",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "eslint-config-prettier": "^9.1.0"
+  }
+}

--- a/tests/integration/rls-negative-tests/partner-profiles.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/partner-profiles.rls-negative.test.ts
@@ -1,0 +1,37 @@
+// M3.A1-T06: RLS negative assertions for `partner_profiles`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+assertsRlsOnTable({
+  tableName: 'partner_profiles',
+  modelKey: 'partnerProfile',
+  seedRow: (seedClient, tenantId) =>
+    seedClient.partnerProfile.create({
+      data: {
+        tenantId,
+        name: `seed-profile-${tenantId}`,
+        partnerType: 'BANK',
+        environment: 'TEST',
+        transportProtocol: 'SFTP',
+        config: {},
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    name: `insert-profile-${tenantId}-${Date.now()}`,
+    partnerType: 'BANK',
+    environment: 'TEST',
+    transportProtocol: 'SFTP',
+    config: {},
+  }),
+  validUpdatePayload: () => ({ notes: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.partnerProfile.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        name: { contains: 'profile' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/refresh-tokens.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/refresh-tokens.rls-negative.test.ts
@@ -1,0 +1,51 @@
+// M3.A1-T06: RLS negative assertions for `refresh_tokens`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+const tenantUserId: Record<string, string> = {};
+
+assertsRlsOnTable({
+  tableName: 'refresh_tokens',
+  modelKey: 'refreshToken',
+  setupParents: async (seedClient) => {
+    for (const tenantId of [TENANT_A_ID, TENANT_B_ID]) {
+      const user = await seedClient.user.create({
+        data: {
+          tenantId,
+          email: `refresh-token-parent-${tenantId}@rls-negative.test`,
+          displayName: `Refresh-token parent for ${tenantId}`,
+        },
+      });
+      tenantUserId[tenantId] = user.id;
+    }
+  },
+  seedRow: (seedClient, tenantId) =>
+    seedClient.refreshToken.create({
+      data: {
+        tenantId,
+        userId: tenantUserId[tenantId]!,
+        // tokenHash is unique — disambiguate per tenant + entropy.
+        tokenHash: `seed-token-${tenantId}-${Date.now()}-${Math.random()}`,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    userId: tenantUserId[tenantId]!,
+    tokenHash: `insert-token-${tenantId}-${Date.now()}-${Math.random()}`,
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  }),
+  validUpdatePayload: () => ({ revocationReason: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.refreshToken.deleteMany({
+      where: { tenantId: { in: [TENANT_A_ID, TENANT_B_ID] } },
+    });
+    await seedClient.user.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        email: { contains: 'refresh-token-parent' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/retention-policies.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/retention-policies.rls-negative.test.ts
@@ -1,0 +1,30 @@
+// M3.A1-T06: RLS negative assertions for `retention_policies`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+assertsRlsOnTable({
+  tableName: 'retention_policies',
+  modelKey: 'retentionPolicy',
+  seedRow: (seedClient, tenantId) =>
+    seedClient.retentionPolicy.create({
+      data: {
+        tenantId,
+        name: `seed-policy-${tenantId}`,
+        description: 'rls-negative seed',
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    name: `insert-policy-${tenantId}-${Date.now()}`,
+  }),
+  validUpdatePayload: () => ({ description: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.retentionPolicy.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        name: { contains: 'policy' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/role-assignments.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/role-assignments.rls-negative.test.ts
@@ -1,0 +1,52 @@
+// M3.A1-T06: RLS negative assertions for `role_assignments`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+// Parent user ids per tenant — needed for the FK userId column. Captured
+// in setupParents and reused by seedRow + validInsertPayload.
+const tenantUserId: Record<string, string> = {};
+
+assertsRlsOnTable({
+  tableName: 'role_assignments',
+  modelKey: 'roleAssignment',
+  setupParents: async (seedClient) => {
+    for (const tenantId of [TENANT_A_ID, TENANT_B_ID]) {
+      const user = await seedClient.user.create({
+        data: {
+          tenantId,
+          email: `roleassign-parent-${tenantId}@rls-negative.test`,
+          displayName: `Role-assign parent for ${tenantId}`,
+        },
+      });
+      tenantUserId[tenantId] = user.id;
+    }
+  },
+  seedRow: (seedClient, tenantId) =>
+    seedClient.roleAssignment.create({
+      data: {
+        tenantId,
+        userId: tenantUserId[tenantId]!,
+        role: 'OPERATIONS_ANALYST',
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    userId: tenantUserId[tenantId]!,
+    // Different role from the seeded one — avoids tripping the (tenantId,
+    // userId, role) unique constraint while still being a valid INSERT.
+    role: 'INTEGRATION_ENGINEER',
+  }),
+  validUpdatePayload: () => ({ scope: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.roleAssignment.deleteMany({
+      where: { tenantId: { in: [TENANT_A_ID, TENANT_B_ID] } },
+    });
+    await seedClient.user.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        email: { contains: 'roleassign-parent' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/source-systems.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/source-systems.rls-negative.test.ts
@@ -1,0 +1,30 @@
+// M3.A1-T06: RLS negative assertions for `source_systems`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+assertsRlsOnTable({
+  tableName: 'source_systems',
+  modelKey: 'sourceSystem',
+  seedRow: (seedClient, tenantId) =>
+    seedClient.sourceSystem.create({
+      data: {
+        tenantId,
+        name: `seed-source-${tenantId}`,
+        description: 'rls-negative seed',
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    name: `insert-source-${tenantId}-${Date.now()}`,
+  }),
+  validUpdatePayload: () => ({ description: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.sourceSystem.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        name: { contains: 'source' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/submissions.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/submissions.rls-negative.test.ts
@@ -1,0 +1,57 @@
+// M3.A1-T06: RLS negative assertions for `submissions`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+const tenantPartnerProfileId: Record<string, string> = {};
+
+assertsRlsOnTable({
+  tableName: 'submissions',
+  modelKey: 'submission',
+  setupParents: async (seedClient) => {
+    for (const tenantId of [TENANT_A_ID, TENANT_B_ID]) {
+      const partner = await seedClient.partnerProfile.create({
+        data: {
+          tenantId,
+          name: `submission-parent-${tenantId}`,
+          partnerType: 'BANK',
+          environment: 'TEST',
+          transportProtocol: 'SFTP',
+          config: {},
+        },
+      });
+      tenantPartnerProfileId[tenantId] = partner.id;
+    }
+  },
+  seedRow: (seedClient, tenantId) =>
+    seedClient.submission.create({
+      data: {
+        tenantId,
+        partnerProfileId: tenantPartnerProfileId[tenantId]!,
+        // (tenantId, idempotencyKey) is unique — disambiguate per tenant.
+        idempotencyKey: `seed-idem-${tenantId}-${Date.now()}-${Math.random()}`,
+        contentType: 'application/json',
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    partnerProfileId: tenantPartnerProfileId[tenantId]!,
+    idempotencyKey: `insert-idem-${tenantId}-${Date.now()}-${Math.random()}`,
+    contentType: 'application/json',
+  }),
+  validUpdatePayload: () => ({ errorMessage: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.submission.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        idempotencyKey: { contains: '-idem-' },
+      },
+    });
+    await seedClient.partnerProfile.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        name: { contains: 'submission-parent' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/tsconfig.json
+++ b/tests/integration/rls-negative-tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "baseUrl": "."
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tests/integration/rls-negative-tests/users.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/users.rls-negative.test.ts
@@ -1,0 +1,36 @@
+// M3.A1-T06: RLS negative assertions for `users`.
+//
+// First file in the suite — also serves as the smoke test that the
+// helper, env contract, and seed/teardown loop work end-to-end. Pattern
+// is identical for the other 16 helper-driven tables; audit_events
+// diverges and lives in its own handwritten file.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+assertsRlsOnTable({
+  tableName: 'users',
+  modelKey: 'user',
+  seedRow: (seedClient, tenantId) =>
+    seedClient.user.create({
+      data: {
+        tenantId,
+        email: `seed-${tenantId}@rls-negative.test`,
+        displayName: `Seed for ${tenantId}`,
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    email: `insert-${tenantId}-${Date.now()}@rls-negative.test`,
+    displayName: 'INSERT probe',
+  }),
+  validUpdatePayload: () => ({ displayName: 'UPDATE probe' }),
+  cleanup: async (seedClient) => {
+    await seedClient.user.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        email: { contains: 'rls-negative.test' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/vitest.config.ts
+++ b/tests/integration/rls-negative-tests/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: '@sep/rls-negative-tests',
+    globals: false,
+    environment: 'node',
+    include: ['**/*.rls-negative.test.ts'],
+    // RLS assertions issue real Postgres roundtrips through pg connection
+    // pools shared across describe blocks; running files sequentially keeps
+    // pool pressure predictable and makes CI flake easier to diagnose.
+    pool: 'forks',
+    fileParallelism: false,
+    // Per-table seeds occasionally chain through 2-3 parent rows; bump
+    // hook timeout so a slow CI runner doesn't false-fail.
+    hookTimeout: 30_000,
+    testTimeout: 15_000,
+  },
+});

--- a/tests/integration/rls-negative-tests/webhook-delivery-attempts.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/webhook-delivery-attempts.rls-negative.test.ts
@@ -1,0 +1,51 @@
+// M3.A1-T06: RLS negative assertions for `webhook_delivery_attempts`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+const tenantWebhookId: Record<string, string> = {};
+
+assertsRlsOnTable({
+  tableName: 'webhook_delivery_attempts',
+  modelKey: 'webhookDeliveryAttempt',
+  setupParents: async (seedClient) => {
+    for (const tenantId of [TENANT_A_ID, TENANT_B_ID]) {
+      const webhook = await seedClient.webhook.create({
+        data: {
+          tenantId,
+          url: `https://rls-negative.test/wda-parent/${tenantId}`,
+          events: ['submission.completed'],
+          secretRef: `vault://webhooks/wda-parent-${tenantId}`,
+        },
+      });
+      tenantWebhookId[tenantId] = webhook.id;
+    }
+  },
+  seedRow: (seedClient, tenantId) =>
+    seedClient.webhookDeliveryAttempt.create({
+      data: {
+        tenantId,
+        webhookId: tenantWebhookId[tenantId]!,
+        eventType: 'submission.completed',
+        success: true,
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    webhookId: tenantWebhookId[tenantId]!,
+    eventType: 'submission.failed',
+    success: false,
+  }),
+  validUpdatePayload: () => ({ errorMessage: 'updated-by-rls-negative' }),
+  cleanup: async (seedClient) => {
+    await seedClient.webhookDeliveryAttempt.deleteMany({
+      where: { tenantId: { in: [TENANT_A_ID, TENANT_B_ID] } },
+    });
+    await seedClient.webhook.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        url: { contains: 'wda-parent' },
+      },
+    });
+  },
+});

--- a/tests/integration/rls-negative-tests/webhooks.rls-negative.test.ts
+++ b/tests/integration/rls-negative-tests/webhooks.rls-negative.test.ts
@@ -1,0 +1,33 @@
+// M3.A1-T06: RLS negative assertions for `webhooks`.
+
+import { TENANT_A_ID, TENANT_B_ID } from './_helpers/clients';
+import { assertsRlsOnTable } from './_helpers/rls-assertions';
+
+assertsRlsOnTable({
+  tableName: 'webhooks',
+  modelKey: 'webhook',
+  seedRow: (seedClient, tenantId) =>
+    seedClient.webhook.create({
+      data: {
+        tenantId,
+        url: `https://rls-negative.test/seed/${tenantId}`,
+        events: ['submission.completed'],
+        secretRef: `vault://webhooks/seed-${tenantId}`,
+      },
+    }),
+  validInsertPayload: (tenantId) => ({
+    tenantId,
+    url: `https://rls-negative.test/insert/${tenantId}-${Date.now()}`,
+    events: ['submission.failed'],
+    secretRef: `vault://webhooks/insert-${tenantId}-${Date.now()}`,
+  }),
+  validUpdatePayload: () => ({ active: false }),
+  cleanup: async (seedClient) => {
+    await seedClient.webhook.deleteMany({
+      where: {
+        tenantId: { in: [TENANT_A_ID, TENANT_B_ID] },
+        url: { contains: 'rls-negative.test' },
+      },
+    });
+  },
+});


### PR DESCRIPTION
Closes M3.A1-T06. Closes M3.A1.

## Summary

144-assertion cross-tenant RLS negative test suite per plan §5-T06 / execution prompt §6 T06. 18 tables × 8 assertions each:

- **17 helper-driven files** — standard cross-tenant isolation pattern (4 no-context + 4 cross-tenant assertions) via the `assertsRlsOnTable` factory.
- **1 handwritten file** — `audit_events` diverges (writes blocked at grant layer via PR #23 REVOKE; SELECT currently permissive via `audit_allow_select` — flips to tenant-scoped in M3.A2).

Wall-clock: ~10s against local docker compose Postgres / GH Actions postgres service.

## What's in the PR

- New workspace `@sep/rls-negative-tests` at `tests/integration/rls-negative-tests/` (added to `pnpm-workspace.yaml`).
- Helper: `_helpers/clients.ts` (seedClient + runtimeClient pair, idempotent two-tenant fixture) + `_helpers/rls-assertions.ts` (`assertsRlsOnTable` 8-assertion factory).
- 17 helper-driven test files (one per standard tenant-scoped table).
- 1 handwritten file (`audit-events.rls-negative.test.ts`) with two TODO(M3.A2) flip points cross-referencing PR #23 round-3 finding and issue #26.
- New CI job `rls-negative-tests` mirroring the integration-tests services + migrate-deploy contract.
- Gotcha #11 added to `_plan/M3_A1_EXECUTION_PROMPT.md` §7 (OR-defeat by pre-existing permissive policies — covers the discovery method that surfaced issue #28).

## Mid-execution discoveries

Two follow-ups filed during T06 execution:

- **#28 — RLS gap on `crypto_operation_records`** (FIXED in PR #29). Same OR-defeat class as PR #23's `audit_events` finding. Surfaced when the helper's first run on `crypto_operation_records` showed 4 unexpected failures. Pause-and-report → fix PR → resume; T06 picks up the table as a normal helper-driven file post-fix.
- **#30 — pg_policies count drift** (NOT BLOCKING). PR #23 documented the post-T04 baseline as 76 rows; actual pre-PR-#29 count was 80. Delta of +4 is unaccounted (likely PR #27 / T05 migrations or untracked elsewhere). Worth reconciling before M3 closes so the documented invariant matches reality.

## Self-review (§10.1 option ii)

### Threat model considered

- **Attack surface:** verification (not enforcement) of the existing M3.A1 controls — RLS policies from PR #23 (T04) and runtime forTenant injection from PR #27 (T05). This PR adds a defense-in-depth verification layer, not new attack surface.
- **OWASP category:** A01:2021 Broken Access Control — verification of cross-tenant authorization is precisely the BAC category. Negative tests prove that bypass attempts (no context, cross-tenant context) fail.
- **CWE:** CWE-639 (authorization bypass via user-controlled key). The 8-assertion shape per table proves four flavors of bypass attempt (no-context SELECT/INSERT/UPDATE/DELETE) and four flavors of cross-tenant bypass (tenant-A context with tenant-B target row) all fail at the DB layer.
- **Discovery dividend:** the suite's first run surfaced an actual previously-undiscovered RLS gap on `crypto_operation_records` (issue #28, fixed in PR #29). Cross-tenant negative tests caught a bug that would otherwise have been latent until a real cross-tenant exploit attempt.

### Test coverage added

- **18 files / 144 assertions** structured as 17 standard + 1 divergent. The standard pattern: 4 no-context (SELECT 0 rows / INSERT throws / UPDATE 0 rows / DELETE 0 rows) + 4 cross-tenant (SELECT 0 tenant-B rows / INSERT with tenantId=B throws / UPDATE on tenant-B 0 rows / DELETE on tenant-B 0 rows). The divergent file (`audit_events`): 6 grant-layer-throws + 2 SELECT-divergence-with-TODO.
- **Negative cases covered (per table, where applicable):** RLS USING fails-closed without GUC; RLS WITH CHECK rejects (NULLIF→NULL); RLS USING hides rows from update/delete without GUC; cross-tenant SELECT excluded; cross-tenant INSERT WITH CHECK rejected; cross-tenant UPDATE/DELETE both protected (USING + WITH CHECK on UPDATE per gotcha #7).
- **Not covered (out of scope for M3.A1, candidates for M3.A8 threat-scenario work):**
  - Cross-column tenant violations — e.g., a submission with valid tenantId referencing a partner_profile belonging to a different tenant. RLS only checks the row's own tenantId, not the FK target's.
  - Concurrent-access races — what happens when two transactions on different tenants interleave with the same `set_config` connection.
  - Fault injection during transactions — e.g., connection drop mid-`SET LOCAL` then resume.
  - Connection-pool tenant leak — a stale GUC surviving across pool acquire/release.
  - Privilege escalation paths via Postgres roles other than `sep_app` (e.g., what if a future role gets BYPASSRLS by mistake).
- **Audit_events divergence** explicitly retains current-behavior assertions (with TODO M3.A2 flip points) rather than skipping. Two visible reminders make the M3.A2 cleanup discipline-point legible to the next executor.

### Rollback path documented

- **Forward rollback:** `git revert` removes the test workspace + CI job + execution-prompt edit. Production paths (RLS policies from PR #23, forTenant runtime from PR #27) are unaffected — this PR adds verification, not enforcement.
- **CI job removal:** if the new `rls-negative-tests` job needs to be temporarily disabled, remove it from `.github/workflows/ci.yml`. Branch protection does not yet enforce it (per M3.A0 deferral on required-checks UI configuration).
- **Workspace removal:** delete `tests/integration/rls-negative-tests/` and the `tests/integration/*` line in `pnpm-workspace.yaml`. Run `pnpm install` to refresh the lockfile.
- **Compensating control if rollback is needed:** the underlying RLS policies and runtime injection continue working. The only loss is the 144-assertion regression check; manual verification or re-introduction of a smaller targeted suite would be the gap-bridging measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)