### PR TITLE
feat(m3.a3): DB timestamps + retention hooks (R2-003)

### DIFF
--- a/packages/db/prisma/migrations/20260419101825_set_updated_at_trigger/migration.sql
+++ b/packages/db/prisma/migrations/20260419101825_set_updated_at_trigger/migration.sql
@@ -1,0 +1,111 @@
+-- M3.A3-T01 + M3.A3-T02 — DB-authored `updatedAt` via trigger.
+--
+-- Closes R2-003 (HIGH): app-layer timestamp writes cannot be trusted as
+-- the authoritative mutation record because (a) client clocks drift,
+-- (b) a compromised or buggy service could backdate a record, and
+-- (c) Prisma's `@updatedAt` sets the value in the outgoing UPDATE
+-- statement — i.e. the app owns the value, not the DB. This migration
+-- moves ownership to the DB: a BEFORE UPDATE trigger rewrites
+-- `"updatedAt"` to `now()` on every UPDATE regardless of what the
+-- client sent. Prisma's own `@updatedAt` still populates on INSERT
+-- (via the Prisma runtime) and on UPDATE (via the same runtime) — the
+-- trigger then overwrites the UPDATE value. Net: the DB always wins on
+-- UPDATE.
+--
+-- Column name: Prisma-generated tables use quoted camelCase
+-- `"updatedAt"` (see 20260412061509_init). The trigger function
+-- references that literal column — renaming the Prisma field would
+-- require a matching migration update.
+--
+-- Tables attached (10, from plan §5-T02):
+--   tenants, users, retention_policies, source_systems,
+--   partner_profiles, exchange_profiles, submissions,
+--   key_references, incidents, webhooks
+--
+-- Deliberately NOT attached:
+--   audit_events              — append-only, BEFORE UPDATE trigger
+--                               already raises 'audit_events is
+--                               append-only' (20260412140000)
+--   crypto_operation_records  — immutable by design (no updatedAt)
+--   api_keys                  — uses explicit `revokedAt`/`lastUsedAt`
+--   role_assignments          — append-only (no updatedAt)
+--   delivery_attempts         — domain-specific timestamps
+--   webhook_delivery_attempts — domain-specific timestamps
+--   inbound_receipts          — domain-specific timestamps
+--   approvals                 — domain-specific timestamps
+--   refresh_tokens            — uses `revokedAt` + `replacedById`
+--
+-- Idempotency: CREATE OR REPLACE FUNCTION is re-runnable. Triggers are
+-- not, so each attachment is preceded by DROP TRIGGER IF EXISTS —
+-- matches the house pattern from M3.A1 migrations. Re-running this
+-- migration against an already-migrated DB is a no-op.
+--
+-- Security mapping: A08:2021 Software and Data Integrity Failures;
+-- CWE-353 Missing Support for Integrity Check.
+
+-- ── Function ──────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW."updatedAt" = now();
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION set_updated_at() IS
+  'M3.A3-T01: BEFORE UPDATE trigger function. Overwrites NEW."updatedAt" with server clock. Attached to 10 mutable tables; see 20260419101825_set_updated_at_trigger.';
+
+-- ── Attachments ───────────────────────────────────────────────────────
+
+DROP TRIGGER IF EXISTS set_updated_at_tenants ON tenants;
+CREATE TRIGGER set_updated_at_tenants
+BEFORE UPDATE ON tenants
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS set_updated_at_users ON users;
+CREATE TRIGGER set_updated_at_users
+BEFORE UPDATE ON users
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS set_updated_at_retention_policies ON retention_policies;
+CREATE TRIGGER set_updated_at_retention_policies
+BEFORE UPDATE ON retention_policies
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS set_updated_at_source_systems ON source_systems;
+CREATE TRIGGER set_updated_at_source_systems
+BEFORE UPDATE ON source_systems
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS set_updated_at_partner_profiles ON partner_profiles;
+CREATE TRIGGER set_updated_at_partner_profiles
+BEFORE UPDATE ON partner_profiles
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS set_updated_at_exchange_profiles ON exchange_profiles;
+CREATE TRIGGER set_updated_at_exchange_profiles
+BEFORE UPDATE ON exchange_profiles
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS set_updated_at_submissions ON submissions;
+CREATE TRIGGER set_updated_at_submissions
+BEFORE UPDATE ON submissions
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS set_updated_at_key_references ON key_references;
+CREATE TRIGGER set_updated_at_key_references
+BEFORE UPDATE ON key_references
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS set_updated_at_incidents ON incidents;
+CREATE TRIGGER set_updated_at_incidents
+BEFORE UPDATE ON incidents
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS set_updated_at_webhooks ON webhooks;
+CREATE TRIGGER set_updated_at_webhooks
+BEFORE UPDATE ON webhooks
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -319,6 +319,16 @@ model RoleAssignment {
 }
 
 // ── Retention Policy (previously missing entity) ───────────────────────────────
+//
+// M3.A3-T03: declarative-only in M3. This model provides per-tenant
+// retention policy *configuration*; enforcement (age-based purge jobs,
+// decrypted-artifact expiry, audit/operator-log/incident-history
+// deletion) is M5 scope (R2-004). Until M5 ships, values in this table
+// are informational — no background job reads them. The fields are
+// intentionally category-specific (encrypted vs decrypted artifacts,
+// audit, operator logs, incidents) rather than a single retentionDays,
+// because each category has different regulatory drivers and the
+// enforcement job in M5 must honor them independently.
 
 model RetentionPolicy {
   id                      String   @id @default(cuid())

--- a/tests/integration/rls-negative-tests/set-updated-at-trigger.test.ts
+++ b/tests/integration/rls-negative-tests/set-updated-at-trigger.test.ts
@@ -1,0 +1,173 @@
+// M3.A3-T02: Integration tests for the DB-authored `"updatedAt"`
+// trigger (migration 20260419101825_set_updated_at_trigger).
+//
+// Three concerns:
+//
+//   (a) Clock-skew / back-date defense — a direct-SQL UPDATE that
+//       explicitly sets `"updatedAt" = '1990-01-01'` must return a
+//       trigger-authored value of now(), not the client's value. This
+//       is the core property R2-003 remediation claims.
+//
+//   (b) Happy path — an ORM update through Prisma also yields a
+//       trigger-authored timestamp. Prisma's own `@updatedAt` sets
+//       the value in the outgoing SQL; the trigger overwrites it.
+//       Net: DB wins.
+//
+//   (c) Coverage — pg_trigger reports exactly 10 `set_updated_at_*`
+//       triggers. Exact-count assertion is defense-in-depth against
+//       future migration drift: if someone attaches the trigger to a
+//       new mutable table without updating this test, or drops a
+//       trigger without noticing, the count test fails loudly. Spot-
+//       checks for a handful of table names guard against renaming.
+//
+// Scope deliberately narrow: this file proves the trigger mechanism on
+// one table (users) and the attachment surface via pg_trigger. It does
+// not re-verify each of the 10 tables individually — the trigger is a
+// single function attached identically to every table, so one direct-
+// SQL probe demonstrates the generic behavior.
+
+import type { PrismaClient } from '@prisma/client';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  ensureTestTenants,
+  hasIntegrationEnv,
+  makeSeedClient,
+  TENANT_A_ID,
+} from './_helpers/clients';
+
+describe.skipIf(!hasIntegrationEnv)('M3.A3 set_updated_at trigger', () => {
+  let seedClient: PrismaClient;
+
+  beforeAll(async () => {
+    seedClient = makeSeedClient();
+    await ensureTestTenants(seedClient);
+  });
+
+  afterAll(async () => {
+    // Probe users are deleted inline per test — nothing persistent to
+    // clean up here.
+    await seedClient.$disconnect();
+  });
+
+  // ─── (a) Clock-skew defense ────────────────────────────────────────────
+
+  describe('direct-SQL UPDATE with back-dated "updatedAt"', () => {
+    it('trigger overwrites client-supplied timestamp with now()', async () => {
+      // Seed: create a user with a very old `updatedAt`. Seed uses the
+      // migration role (sep, BYPASSRLS) so the row exists regardless of
+      // runtime policy state.
+      const email = `trigger-probe-skew-${Date.now()}@rls-negative.test`;
+      const user = await seedClient.user.create({
+        data: {
+          tenantId: TENANT_A_ID,
+          email,
+          displayName: 'Trigger probe initial',
+        },
+      });
+
+      const before = new Date();
+
+      // Direct-SQL UPDATE that tries to back-date `updatedAt` to 1990.
+      // $executeRaw bypasses Prisma's `@updatedAt` behavior — this is
+      // the worst case for the trigger: a caller actively trying to
+      // write a stale timestamp.
+      await seedClient.$executeRaw`
+        UPDATE users
+        SET "displayName" = 'Trigger probe updated',
+            "updatedAt"   = '1990-01-01 00:00:00'
+        WHERE id = ${user.id}
+      `;
+
+      const after = new Date();
+
+      const row = await seedClient.user.findUniqueOrThrow({ where: { id: user.id } });
+
+      // Trigger-authored timestamp must be between test start and end.
+      // If the trigger had not fired, the value would be '1990-01-01'.
+      expect(row.updatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(row.updatedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+      expect(row.displayName).toBe('Trigger probe updated');
+
+      await seedClient.user.delete({ where: { id: user.id } });
+    });
+  });
+
+  // ─── (b) Happy path via Prisma ─────────────────────────────────────────
+
+  describe('Prisma-driven UPDATE (happy path)', () => {
+    it('trigger also fires on Prisma-authored UPDATE statements', async () => {
+      const email = `trigger-probe-prisma-${Date.now()}@rls-negative.test`;
+      const user = await seedClient.user.create({
+        data: {
+          tenantId: TENANT_A_ID,
+          email,
+          displayName: 'Prisma probe initial',
+        },
+      });
+
+      const before = new Date();
+      const updated = await seedClient.user.update({
+        where: { id: user.id },
+        data: { displayName: 'Prisma probe updated' },
+      });
+      const after = new Date();
+
+      // Prisma's @updatedAt writes a value; the trigger overwrites it.
+      // Both paths converge on a server-clock value — the test cannot
+      // distinguish which one won from the outside. What it can check
+      // is that the final value is a valid server-clock reading, which
+      // is the only invariant users of the column actually care about.
+      expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(updated.updatedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+
+      await seedClient.user.delete({ where: { id: user.id } });
+    });
+  });
+
+  // ─── (c) Attachment coverage ───────────────────────────────────────────
+
+  describe('pg_trigger attachment coverage', () => {
+    it('exactly 10 set_updated_at_* triggers exist', async () => {
+      // Exact-count assertion: catches both directions of drift.
+      //  * 9 = a trigger was dropped without updating this test
+      //  * 11+ = trigger was attached to a new table without updating
+      //          either this test or the migration's documented table
+      //          list
+      // Both are failure modes worth failing the gate on.
+      type TriggerRow = { tgname: string; table_name: string };
+      const triggers = await seedClient.$queryRaw<TriggerRow[]>`
+        SELECT tgname, tgrelid::regclass::text AS table_name
+        FROM pg_trigger
+        WHERE tgname LIKE 'set_updated_at_%'
+          AND NOT tgisinternal
+        ORDER BY tgname
+      `;
+
+      expect(triggers).toHaveLength(10);
+
+      // Spot-check three tables from different parts of the domain
+      // (tenant identity, submission flow, ops). If the migration ever
+      // renamed a trigger or a table the mapping would break here.
+      const tableNames = triggers.map((row) => row.table_name);
+      expect(tableNames).toContain('tenants');
+      expect(tableNames).toContain('users');
+      expect(tableNames).toContain('submissions');
+    });
+
+    it('append-only tables are deliberately excluded from the trigger', async () => {
+      // Guardrail: if someone were to attach set_updated_at to
+      // audit_events or crypto_operation_records, those tables would
+      // start having their timestamps mutated — undermining the
+      // append-only / immutable guarantee. Check the exclusion.
+      type TriggerRow = { tgname: string };
+      const triggers = await seedClient.$queryRaw<TriggerRow[]>`
+        SELECT tgname
+        FROM pg_trigger
+        WHERE tgname LIKE 'set_updated_at_%'
+          AND tgrelid::regclass::text IN ('audit_events', 'crypto_operation_records')
+      `;
+      expect(triggers).toHaveLength(0);
+    });
+  });
+});

--- a/tests/integration/rls-negative-tests/vitest.config.ts
+++ b/tests/integration/rls-negative-tests/vitest.config.ts
@@ -8,7 +8,13 @@ export default defineConfig({
     // The original M3.A1-T06 suite uses `*.rls-negative.test.ts`. M3.A2-T04
     // adds `audit-transactional-coupling.test.ts` which exercises atomicity
     // and append-only enforcement (related but not strictly RLS-negative).
-    include: ['**/*.rls-negative.test.ts', '**/audit-transactional-coupling.test.ts'],
+    // M3.A3-T02 adds `set-updated-at-trigger.test.ts` for the DB-authored
+    // timestamp trigger (uses the same Postgres fixture + tenant seeds).
+    include: [
+      '**/*.rls-negative.test.ts',
+      '**/audit-transactional-coupling.test.ts',
+      '**/set-updated-at-trigger.test.ts',
+    ],
     // RLS assertions issue real Postgres roundtrips through pg connection
     // pools shared across describe blocks; running files sequentially keeps
     // pool pressure predictable and makes CI flake easier to diagnose.


### PR DESCRIPTION
## Summary

- Closes R2-003 (HIGH) by moving `updatedAt` ownership from the app layer to the DB via a BEFORE UPDATE trigger attached to 10 mutable tables.
- Documents M3-scope retention policy as declarative-only — enforcement deferred to M5 (R2-004).
- Adds integration tests that prove the trigger overwrites client-supplied timestamps and that the attachment surface matches the plan (exact count + spot-check + exclusion guardrail).

## Scope per plan §5-M3.A3

- **T01** — `set_updated_at()` trigger function (`packages/db/prisma/migrations/20260419101825_set_updated_at_trigger`)
- **T02** — Trigger attached to 10 tables: `tenants`, `users`, `retention_policies`, `source_systems`, `partner_profiles`, `exchange_profiles`, `submissions`, `key_references`, `incidents`, `webhooks`
- **T03** — RetentionPolicy M5-deferral comment in `schema.prisma` (model already existed with richer per-category day fields)

## Exit criteria

- [x] `set_updated_at()` trigger active on 10 mutable tables
- [x] Integration test proves trigger-authored timestamp (clock-skew probe + Prisma path)
- [x] Retention policy hooks documented as M5-deferred

## Commit sequence

1. `feat(m3.a3): set_updated_at trigger function + attach to 10 mutable tables` — single migration bundling T01 + T02 (one semantic change, no meaningful intermediate state)
2. `feat(m3.a3): retention policy schema hooks (enforcement M5)` — comment-only schema change
3. `test(m3.a3): integration tests for set_updated_at trigger` — 4 assertions in new test file + vitest.config.ts include

## Self-review (per §10.1 option (ii))

**What I verified before marking task done**
- Migration applies cleanly to a fresh DB (`prisma migrate deploy`): 14 migrations including new one, no errors.
- Trigger behavior confirmed at the SQL layer: `UPDATE tenants SET "updatedAt" = '1990-01-01'` returns `2026-04-19 …` from the trigger.
- `pg_trigger` shows exactly 10 `set_updated_at_*` triggers after migration.
- All 4 new test assertions pass against fresh-migrated DB.
- Full `@sep/rls-negative-tests` suite: 156/156 green (20 test files).
- `pnpm typecheck`: 16/16 after clean build.
- `pnpm format:check`: clean.
- `pnpm test:unit`: 14/14.
- `pnpm build`: 9/9 after purging stale tsbuildinfo (issue #21).

**Deliberate choices worth flagging**
- **Column name is `"updatedAt"` (quoted camelCase), not `updated_at`.** Plan §5-T01 acceptance SQL was pseudo-code; Prisma-generated tables use the camelCase field name as the actual column identifier. The migration references it correctly and the test exercises it directly via `$executeRaw`.
- **T01 + T02 bundled in one migration.** Splitting into two migrations would leave an intermediate state (function exists, no triggers) with no semantic meaning. Plan commit shapes are suggestions; this bundle is the natural atomic unit.
- **Retention policy: comment-only change.** The existing model already has 5 category-specific day fields and `legalHold`, superseding the plan's placeholder suggestion (`retentionDays` + `appliesTo`). Plan §5-T03 explicitly anticipates this case (effort: "minimal if RetentionPolicy exists"). No schema restructure needed — only the M5-deferral comment so future readers understand why the fields appear unused until the purge workers ship.
- **Test uses `seedClient` (BYPASSRLS `sep` role) for introspection and trigger probes.** The trigger fires regardless of role, so `sep_app` would also work, but `sep` has unambiguous access to `pg_trigger` and doesn't require a tenant-scoped transaction. Cross-tenant RLS testing already lives in the sibling files.

**Pre-existing local/CI drift observed (not introduced by this PR)**
- `pnpm lint` locally emits 7 `require-await` errors in `audit-events.rls-negative.test.ts` and `audit-transactional-coupling.test.ts`. Confirmed these exist on `main` at 51b8b43 by `git checkout main && pnpm --filter @sep/rls-negative-tests lint` — CI passed the same commit. Filed comment on #33 explaining CI's typed-rule emission differs from local. Not fixed here (out of scope for M3.A3; M3.A10 sweep).
- `pnpm build` required purging stale `.tsbuildinfo` before re-emitting `packages/common/dist/index.d.ts` (classic #21).

## Follow-ups filed

- #33 — Local vs CI gate scope drift (lint-staged/format:check/tsbuildinfo + now also typed-lint rule evaluation) — commented with the new data point.

## Test plan

- [x] Migration deploys cleanly (local + CI)
- [x] `set-updated-at-trigger.test.ts` — 4/4 pass
- [x] Full rls-negative-tests — 156/156 pass
- [x] No regression in unit/typecheck/format

🤖 Generated with [Claude Code](https://claude.com/claude-code)