### PR TITLE
test(m3.a8): auth threat scenarios T1, T12, T13 + HttpExceptionFilter code-hoist fix (PR 2/5)

### DIFF
--- a/apps/control-plane/src/common/filters/http-exception.filter.ts
+++ b/apps/control-plane/src/common/filters/http-exception.filter.ts
@@ -54,11 +54,30 @@ export class HttpExceptionFilter implements ExceptionFilter {
     } else if (normalised instanceof HttpException) {
       status = normalised.getStatus();
       const resp = normalised.getResponse();
-      message =
-        typeof resp === 'string'
-          ? resp
-          : (((resp as Record<string, unknown>)['message'] as string | undefined) ?? message);
-      logger.warn({ status, message, correlationId }, 'HttpException');
+      if (typeof resp === 'string') {
+        message = resp;
+      } else {
+        const record = resp as Record<string, unknown>;
+        message = (record['message'] as string | undefined) ?? message;
+        // Services sometimes wrap a SepError in an HttpException
+        // (e.g. `new UnauthorizedException(sepError.toClientJson())`).
+        // When that happens the response body already carries the
+        // SepError contract fields; hoist them so clients don't see
+        // the default INTERNAL_ERROR code with the SepError message.
+        const respCode = record['code'];
+        if (typeof respCode === 'string') {
+          code = respCode;
+        }
+        const respRetryable = record['retryable'];
+        if (typeof respRetryable === 'boolean') {
+          retryable = respRetryable;
+        }
+        const respTerminal = record['terminal'];
+        if (typeof respTerminal === 'boolean') {
+          terminal = respTerminal;
+        }
+      }
+      logger.warn({ status, message, code, correlationId }, 'HttpException');
     } else {
       logger.error({ correlationId, err: normalised }, 'Unhandled exception');
     }

--- a/apps/control-plane/src/modules/auth/T01_stolen_credential.threat.test.ts
+++ b/apps/control-plane/src/modules/auth/T01_stolen_credential.threat.test.ts
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, no-process-env */
+
+/**
+ * Threat scenario T1 — Stolen operator credential (M3.A8).
+ *
+ * Plan §6 scenario ID: T1. Primary control: MFA requirement, access-
+ * token TTL, lockout (the latter is exercised in T13).
+ *
+ * Attack model:
+ *   Attacker has stolen a user's password (phishing, reuse, breach).
+ *   The user has MFA enrolled. Attacker presents the correct password
+ *   and expects an access token. Defense: LoginService MUST return an
+ *   MFA challenge token, NOT an access token. The attacker has no
+ *   path to a usable access token without the TOTP (or recovery
+ *   code).
+ *
+ * Defense mechanism:
+ *   LoginService.validatePassword, after successful argon2Verify, checks
+ *   `user.mfaEnrolledAt !== null` and branches to `issueMfaChallenge()`
+ *   which returns only `{ mfaChallengeToken, expiresIn: '5m' }` —
+ *   with no `accessToken` in the payload.
+ *
+ * Test is service-level (does not exercise HTTP) because the branching
+ * decision sits inside LoginService. Observing the service return
+ * shape directly is the clearest way to assert the invariant.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaClient } from '@prisma/client';
+import { hash as argon2Hash } from '@node-rs/argon2';
+import { DatabaseService } from '@sep/db';
+import { LoginService } from './login.service';
+import { AuthService } from './auth.service';
+import type { RefreshTokenService } from './refresh-token.service';
+
+const SCENARIO_ID = 'T01_stolen_operator_credential';
+const TENANT_ID = 'cthreatsc01stolenownr0001';
+const CORRECT_PASSWORD = 'correct-horse-battery-staple-2026';
+
+const MIGRATION_URL = process.env['DATABASE_URL'];
+const RUNTIME_URL = process.env['RUNTIME_DATABASE_URL'];
+const hasInfra = typeof MIGRATION_URL === 'string' && typeof RUNTIME_URL === 'string';
+
+/**
+ * LoginService's MFA branch calls `getConfig()` to read the JWT
+ * secret for signing the challenge token. Zod validation on the
+ * config requires several fields that the threat-test process
+ * doesn't otherwise need. Populate them with test-value defaults
+ * BEFORE `@sep/common` loads its singleton.
+ */
+function ensureTestEnv(): void {
+  const defaults: Record<string, string> = {
+    JWT_SECRET: 'threat-scenario-test-jwt-secret-minimum-32-chars',
+    REFRESH_TOKEN_SECRET: 'threat-scenario-test-refresh-secret-minimum-32-chars',
+    INTERNAL_SERVICE_TOKEN: 'threat-scenario-test-internal-service-token',
+    WEBHOOK_SIGNING_SECRET: 'threat-scenario-test-webhook-signing-secret-32',
+    AUDIT_HASH_SECRET: 'threat-scenario-test-audit-hash-secret-min32ch',
+    STORAGE_ENDPOINT: 'http://localhost:9000',
+    STORAGE_ACCESS_KEY: 'test',
+    STORAGE_SECRET_KEY: 'test',
+    STORAGE_BUCKET_PAYLOADS: 'test-payloads',
+    STORAGE_BUCKET_AUDIT_EXPORTS: 'test-audit-exports',
+    VAULT_ADDR: 'http://localhost:8200',
+    VAULT_TOKEN: 'test-vault-token',
+  };
+  for (const [k, v] of Object.entries(defaults)) {
+    if (process.env[k] === undefined) {
+      process.env[k] = v;
+    }
+  }
+}
+ensureTestEnv();
+
+describe.skipIf(!hasInfra)(
+  `[${SCENARIO_ID}] stolen password cannot bypass MFA — correct password on MFA-enrolled user returns only an MFA challenge`,
+  () => {
+    let seedClient: PrismaClient;
+    let runtimeClient: PrismaClient;
+    let loginService: LoginService;
+    const email = 't01-stolen-credential@sep.test';
+
+    beforeAll(async () => {
+      seedClient = new PrismaClient({
+        ...(MIGRATION_URL !== undefined && { datasourceUrl: MIGRATION_URL }),
+      });
+      runtimeClient = new PrismaClient({
+        ...(RUNTIME_URL !== undefined && { datasourceUrl: RUNTIME_URL }),
+      });
+      const db = new DatabaseService(runtimeClient);
+
+      const jwt = new JwtService({ secret: 'threat-scenario-test-secret-minimum-32-chars' });
+      const authService = {
+        issueToken: (): { accessToken: string; expiresIn: string } => ({
+          accessToken: 'SHOULD_NOT_REACH_THIS_BRANCH',
+          expiresIn: '15m',
+        }),
+      } as unknown as AuthService;
+      const refreshTokenService = {
+        issue: (): Promise<{ token: string; expiresAt: Date }> =>
+          Promise.resolve({
+            token: 'SHOULD_NOT_REACH_THIS_BRANCH',
+            expiresAt: new Date(Date.now() + 86_400_000),
+          }),
+      } as unknown as RefreshTokenService;
+      loginService = new LoginService(db, jwt, authService, refreshTokenService);
+
+      await seedClient.tenant.upsert({
+        where: { id: TENANT_ID },
+        update: {},
+        create: {
+          id: TENANT_ID,
+          name: `Threat-Scenario ${SCENARIO_ID}`,
+          legalEntityName: `Threat-Scenario ${SCENARIO_ID} LLC`,
+        },
+      });
+      await seedClient.user.deleteMany({ where: { tenantId: TENANT_ID, email } });
+      const passwordHash = await argon2Hash(CORRECT_PASSWORD);
+      await seedClient.user.create({
+        data: {
+          tenantId: TENANT_ID,
+          email,
+          displayName: 'T01 stolen-credential victim',
+          passwordHash,
+          // MFA enrolled. mfaSecretRef points at a Vault path the
+          // service resolves later in /auth/mfa/verify — not needed
+          // here because T1 proves the PRE-TOTP branching property.
+          mfaEnrolledAt: new Date(),
+          mfaSecretRef: 'platform/mfa-secrets/t01-victim-not-exercised',
+        },
+      });
+    }, 30_000);
+
+    afterAll(async () => {
+      await seedClient.user.deleteMany({ where: { tenantId: TENANT_ID, email } });
+      await seedClient.$disconnect();
+      await runtimeClient.$disconnect();
+    });
+
+    it('correct password on MFA-enrolled user returns ONLY an MFA challenge — no access token issued', async () => {
+      const result = await loginService.validatePassword(TENANT_ID, email, CORRECT_PASSWORD);
+
+      // The attacker's expectation: { accessToken, expiresIn }.
+      // Reality: { mfaChallengeToken, expiresIn }.
+      expect('accessToken' in result).toBe(false);
+      expect('refreshToken' in result).toBe(false);
+      expect('mfaChallengeToken' in result).toBe(true);
+      const challenge = (result as { mfaChallengeToken: string; expiresIn: string })
+        .mfaChallengeToken;
+      expect(typeof challenge).toBe('string');
+      expect(challenge.length).toBeGreaterThan(0);
+    });
+
+    it('MFA challenge token carries typ=mfa_challenge and cannot be used as an access token', async () => {
+      const result = await loginService.validatePassword(TENANT_ID, email, CORRECT_PASSWORD);
+      const challenge = (result as { mfaChallengeToken: string }).mfaChallengeToken;
+
+      // Decode the JWT payload without verifying (structure inspection only).
+      const parts = challenge.split('.');
+      expect(parts.length).toBe(3);
+      const partOne = parts[1] ?? '';
+      const payload = JSON.parse(Buffer.from(partOne, 'base64url').toString('utf8')) as {
+        typ?: string;
+        userId?: string;
+        tenantId?: string;
+      };
+      // typ discriminates the challenge token from an access token.
+      // MfaVerifyService re-checks this claim before consuming; any
+      // access-token-shaped JWT presented to /auth/mfa/verify would
+      // fail the typ guard.
+      expect(payload.typ).toBe('mfa_challenge');
+      expect(payload.tenantId).toBe(TENANT_ID);
+    });
+  },
+);

--- a/apps/control-plane/src/modules/auth/T12_refresh_token_replay.threat.test.ts
+++ b/apps/control-plane/src/modules/auth/T12_refresh_token_replay.threat.test.ts
@@ -1,0 +1,157 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, no-process-env */
+
+/**
+ * Threat scenario T12 — Refresh token theft / replay (M3.A8).
+ *
+ * Plan §6 scenario ID: T12. Primary control: one-shot refresh
+ * token rotation; replay-detection chain revocation.
+ *
+ * Attack model:
+ *   1. Legitimate client issues refresh token A, rotates A→B, B→C.
+ *   2. Attacker captures A (for example from a captured log export
+ *      or a mishandled browser storage).
+ *   3. Attacker presents A to /auth/refresh.
+ *   4. Expected: A, B, C all revoked (replay-detected), and
+ *      AUTH_REFRESH_TOKEN_REPLAY returned. The legitimate client's
+ *      current token C is ALSO revoked so the attacker-or-legit
+ *      collusion ends the session entirely. Caller must re-login.
+ *
+ * Defense mechanism:
+ *   RefreshTokenService.refresh observes `usedAt != null` on the
+ *   presented row (because A was rotated already), triggers
+ *   `revokeChain(tenantId, row.id)` which walks `replacedById` in
+ *   BOTH directions, and updates every reachable row with
+ *   `revocationReason = 'replay-detected'`.
+ *
+ * The same behavior is exercised by auth-lifecycle.integration.test.ts
+ * Scenario 2 from M3.A4-T06. This scenario frames the property as a
+ * discrete THREAT-scenario test with the plan §6 scenario ID, so a
+ * CI run filtered to `[T*` describe prefixes surfaces the refresh-
+ * replay coverage distinctly.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { DatabaseService } from '@sep/db';
+import { ErrorCode } from '@sep/common';
+import { RefreshTokenService } from './refresh-token.service';
+import { hmacToken } from './refresh-hmac-key.provider';
+
+const SCENARIO_ID = 'T12_refresh_token_replay';
+const TENANT_ID = 'cthreatsc12refreshown0001';
+
+const MIGRATION_URL = process.env['DATABASE_URL'];
+const RUNTIME_URL = process.env['RUNTIME_DATABASE_URL'];
+const hasInfra = typeof MIGRATION_URL === 'string' && typeof RUNTIME_URL === 'string';
+
+describe.skipIf(!hasInfra)(
+  `[${SCENARIO_ID}] replaying a used refresh token revokes the entire chain`,
+  () => {
+    let seedClient: PrismaClient;
+    let runtimeClient: PrismaClient;
+    let refreshTokenService: RefreshTokenService;
+    let hmacKey: Buffer;
+    let userId: string;
+    const email = 't12-refresh-replay@sep.test';
+
+    beforeAll(async () => {
+      seedClient = new PrismaClient({
+        ...(MIGRATION_URL !== undefined && { datasourceUrl: MIGRATION_URL }),
+      });
+      runtimeClient = new PrismaClient({
+        ...(RUNTIME_URL !== undefined && { datasourceUrl: RUNTIME_URL }),
+      });
+      const db = new DatabaseService(runtimeClient);
+
+      // Deterministic HMAC key so recomputing hashes in assertions
+      // matches the ones the service persisted.
+      hmacKey = Buffer.alloc(32, 0x7a);
+      refreshTokenService = new RefreshTokenService(db, hmacKey);
+
+      await seedClient.tenant.upsert({
+        where: { id: TENANT_ID },
+        update: {},
+        create: {
+          id: TENANT_ID,
+          name: `Threat-Scenario ${SCENARIO_ID}`,
+          legalEntityName: `Threat-Scenario ${SCENARIO_ID} LLC`,
+        },
+      });
+      await seedClient.user.deleteMany({ where: { tenantId: TENANT_ID, email } });
+      const u = await seedClient.user.create({
+        data: { tenantId: TENANT_ID, email, displayName: 'T12 victim' },
+      });
+      userId = u.id;
+    }, 30_000);
+
+    afterAll(async () => {
+      await seedClient.refreshToken.deleteMany({ where: { tenantId: TENANT_ID, userId } });
+      await seedClient.user.deleteMany({ where: { tenantId: TENANT_ID, email } });
+      await seedClient.$disconnect();
+      await runtimeClient.$disconnect();
+    });
+
+    beforeEach(async () => {
+      await seedClient.refreshToken.deleteMany({ where: { tenantId: TENANT_ID, userId } });
+    });
+
+    it('attacker replaying token A (after legit rotation to B and C) revokes A, B, C with replay-detected', async () => {
+      const db = new DatabaseService(runtimeClient);
+
+      // Step 1 — legitimate flow: issue A, rotate A→B, rotate B→C.
+      const issuedA = await db.forTenant(TENANT_ID, (tx) =>
+        refreshTokenService.issue(tx, TENANT_ID, userId),
+      );
+      const resultB = await refreshTokenService.refresh(issuedA.token);
+      const resultC = await refreshTokenService.refresh(resultB.refreshToken.token);
+
+      // Step 2 — attacker replays A.
+      await expect(refreshTokenService.refresh(issuedA.token)).rejects.toMatchObject({
+        response: expect.objectContaining({ code: ErrorCode.AUTH_REFRESH_TOKEN_REPLAY }),
+      });
+
+      // Step 3 — assert the whole chain is revoked with the
+      // replay-detected reason. A, B, AND C must all carry the mark.
+      const tokens = await seedClient.refreshToken.findMany({
+        where: { tenantId: TENANT_ID, userId },
+        select: {
+          tokenHash: true,
+          revokedAt: true,
+          revocationReason: true,
+        },
+      });
+      expect(tokens).toHaveLength(3);
+      for (const t of tokens) {
+        expect(t.revokedAt).not.toBeNull();
+        expect(t.revocationReason).toBe('replay-detected');
+      }
+      // Verify the chain covered A (the replayed token), B, and C.
+      const hashA = hmacToken(issuedA.token, hmacKey);
+      const hashB = hmacToken(resultB.refreshToken.token, hmacKey);
+      const hashC = hmacToken(resultC.refreshToken.token, hmacKey);
+      const hashes = new Set(tokens.map((t) => t.tokenHash));
+      expect(hashes.has(hashA)).toBe(true);
+      expect(hashes.has(hashB)).toBe(true);
+      expect(hashes.has(hashC)).toBe(true);
+    });
+
+    it('presenting C (the current legit token) AFTER the replay detection returns AUTH_REFRESH_TOKEN_INVALID, not a new rotation', async () => {
+      // Run the attack once to lock down the chain; reuse fixture.
+      const db = new DatabaseService(runtimeClient);
+      const issuedA = await db.forTenant(TENANT_ID, (tx) =>
+        refreshTokenService.issue(tx, TENANT_ID, userId),
+      );
+      const resultB = await refreshTokenService.refresh(issuedA.token);
+      const resultC = await refreshTokenService.refresh(resultB.refreshToken.token);
+      await expect(refreshTokenService.refresh(issuedA.token)).rejects.toBeDefined();
+
+      // C is revoked by chain revocation; legit client trying to
+      // rotate it fails with AUTH_REFRESH_TOKEN_INVALID (revoked),
+      // NOT AUTH_REFRESH_TOKEN_REPLAY — revoked tokens are a known
+      // state, replay detection only fires on usedAt != null.
+      await expect(refreshTokenService.refresh(resultC.refreshToken.token)).rejects.toMatchObject({
+        response: expect.objectContaining({ code: ErrorCode.AUTH_REFRESH_TOKEN_INVALID }),
+      });
+    });
+  },
+);

--- a/apps/control-plane/src/modules/auth/T13_brute_force.threat.test.ts
+++ b/apps/control-plane/src/modules/auth/T13_brute_force.threat.test.ts
@@ -1,0 +1,327 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, no-await-in-loop, no-process-env */
+
+/**
+ * Threat scenario T13 — Brute-force login (M3.A8).
+ *
+ * Plan §6 scenario ID: T13. Primary control: rate limiting (edge +
+ * NestJS throttler) AND M3.A4 account lockout. This test proves
+ * BOTH layers fire, in the right order, against a brute-force
+ * attack on a single user's email.
+ *
+ * Defense-in-depth narrative:
+ *   - Controller throttler fires at 5 attempts per (IP, email) /
+ *     15min. Beyond that, login requests get 429 before LoginService
+ *     even runs. This protects the lockout counter from being
+ *     exhausted by a trivial flood.
+ *   - M3.A4 lockout fires at 10 total failures within a 30-min
+ *     window. An attacker who bypasses the throttler (via multiple
+ *     IPs, or by waiting out the 15-min window) still gets capped
+ *     at the user level.
+ *   - A locked account returns AUTH_ACCOUNT_LOCKED even on CORRECT
+ *     password until lockedUntil passes.
+ *
+ * Lives inside apps/control-plane (not tests/threat-scenarios/)
+ * because it imports LoginService + SepThrottlerGuard directly.
+ * Picked up by vitest.integration.config.ts's `**\/*.threat.test.ts`
+ * include glob. See `_plan/M3_A8_SELF_REVIEW.md` for the full
+ * scenario-to-host-package map.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Controller, Module, Post, Body, Inject } from '@nestjs/common';
+import { APP_GUARD, Reflector } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
+import { ZodValidationPipe } from 'nestjs-zod';
+import { ThrottlerModule, Throttle } from '@nestjs/throttler';
+import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis';
+import { JwtService } from '@nestjs/jwt';
+import Redis from 'ioredis';
+import { hash as argon2Hash } from '@node-rs/argon2';
+import { PrismaClient } from '@prisma/client';
+import { DatabaseService } from '@sep/db';
+import { HttpExceptionFilter } from '../../common/filters/http-exception.filter';
+import { SepThrottlerGuard } from '../../common/guards/sep-throttler.guard';
+import { THROTTLER_NAMES, loginEmailTracker } from '../../common/throttler-config';
+import { LoginService } from './login.service';
+import { AuthService } from './auth.service';
+
+// Scenario-local constants (inlined from tests/threat-scenarios/_helpers/
+// to avoid cross-workspace deep imports; see the M3.A8 self-review for
+// the scaffolding-vs-in-package tradeoff).
+const SCENARIO_ID = 'T13_brute_force_login';
+const TENANT_ID = 'cthreatsc13bruteforceown1';
+const VICTIM_EMAIL = 't13-brute-force-victim@sep.test';
+const CORRECT_PASSWORD = 'correct-horse-battery-staple-2026';
+const WRONG_PASSWORD = 'wrong-password-guess';
+
+const MIGRATION_URL = process.env['DATABASE_URL'];
+const RUNTIME_URL = process.env['RUNTIME_DATABASE_URL'];
+const REDIS_URL = process.env['REDIS_URL'];
+const hasInfra =
+  typeof MIGRATION_URL === 'string' &&
+  typeof RUNTIME_URL === 'string' &&
+  typeof REDIS_URL === 'string';
+
+describe.skipIf(!hasInfra)(
+  `[${SCENARIO_ID}] brute-force login hits rate-limit BEFORE exhausting lockout counter`,
+  () => {
+    let app: NestFastifyApplication;
+    let seedClient: PrismaClient;
+    let runtimeClient: PrismaClient;
+    let redis: Redis;
+    /**
+     * Admin Redis client WITHOUT keyPrefix so beforeEach can DEL
+     * the fully-qualified throttler keys. ioredis applies keyPrefix
+     * to all commands (including DEL) but returns keys from KEYS/SCAN
+     * with the prefix baked in — deleting those via the prefixed
+     * client would double-prefix and no-op. The admin client sees the
+     * raw Redis keyspace.
+     */
+    let redisAdmin: Redis;
+    let prefix: string;
+
+    beforeAll(async () => {
+      seedClient = new PrismaClient({
+        ...(MIGRATION_URL !== undefined && { datasourceUrl: MIGRATION_URL }),
+      });
+      runtimeClient = new PrismaClient({
+        ...(RUNTIME_URL !== undefined && { datasourceUrl: RUNTIME_URL }),
+      });
+      const db = new DatabaseService(runtimeClient);
+
+      // Scenario-scoped keyPrefix isolates throttler state across
+      // parallel threat-suite runs.
+      prefix = `sep:threat:${SCENARIO_ID}:${String(Date.now())}:`;
+      redis = new Redis(REDIS_URL ?? 'redis://localhost:6379', {
+        keyPrefix: prefix,
+        lazyConnect: false,
+        maxRetriesPerRequest: 3,
+      });
+      redisAdmin = new Redis(REDIS_URL ?? 'redis://localhost:6379', {
+        lazyConnect: false,
+        maxRetriesPerRequest: 3,
+      });
+
+      // Upsert the scenario tenant (idempotent) + seed victim with a
+      // real argon2id password hash.
+      await seedClient.tenant.upsert({
+        where: { id: TENANT_ID },
+        update: {},
+        create: {
+          id: TENANT_ID,
+          name: `Threat-Scenario ${SCENARIO_ID}`,
+          legalEntityName: `Threat-Scenario ${SCENARIO_ID} LLC`,
+        },
+      });
+      await seedClient.user.deleteMany({ where: { tenantId: TENANT_ID, email: VICTIM_EMAIL } });
+      const passwordHash = await argon2Hash(CORRECT_PASSWORD);
+      await seedClient.user.create({
+        data: {
+          tenantId: TENANT_ID,
+          email: VICTIM_EMAIL,
+          displayName: 'Brute Force Victim',
+          passwordHash,
+          failedLoginAttempts: 0,
+          lockedUntil: null,
+        },
+      });
+
+      // Controller declared inside beforeAll — at this scope, tsc's
+      // emitDecoratorMetadata doesn't propagate the constructor
+      // parameter types reliably, so we use an explicit injection
+      // token.
+      @Controller('auth')
+      class TestLoginController {
+        constructor(@Inject(LoginService) private readonly login: LoginService) {}
+
+        @Throttle({
+          [THROTTLER_NAMES.authLogin]: { limit: 5, ttl: 15 * 60_000 },
+        })
+        @Post('login')
+        async loginRoute(
+          @Body() body: { tenantId: string; email: string; password: string },
+        ): Promise<unknown> {
+          return this.login.validatePassword(body.tenantId, body.email, body.password);
+        }
+      }
+
+      @Module({
+        imports: [
+          ThrottlerModule.forRoot({
+            throttlers: [
+              { name: THROTTLER_NAMES.default, ttl: 60_000, limit: 1000 },
+              {
+                name: THROTTLER_NAMES.authLogin,
+                ttl: 15 * 60_000,
+                limit: 5,
+                getTracker: loginEmailTracker,
+              },
+            ],
+            storage: new ThrottlerStorageRedisService(redis),
+          }),
+        ],
+        controllers: [TestLoginController],
+        providers: [
+          Reflector,
+          { provide: DatabaseService, useValue: db },
+          { provide: JwtService, useValue: { sign: (): string => 'unused-in-t13' } },
+          {
+            // AuthService.issueToken lives on the success path; T13
+            // focuses on the PRE-issue layers (throttler + lockout),
+            // so a stub return is sufficient.
+            provide: AuthService,
+            useValue: {
+              issueToken: (): { accessToken: string; expiresIn: string } => ({
+                accessToken: 'test-access',
+                expiresIn: '15m',
+              }),
+            },
+          },
+          {
+            // RefreshTokenService.issue is called on the no-MFA
+            // success branch. Same stub rationale.
+            provide: 'RefreshTokenServiceMock',
+            useValue: {
+              issue: (): Promise<{ token: string; expiresAt: Date }> =>
+                Promise.resolve({
+                  token: 'test-refresh',
+                  expiresAt: new Date(Date.now() + 86_400_000),
+                }),
+            },
+          },
+          {
+            provide: LoginService,
+            useFactory: (
+              database: DatabaseService,
+              jwt: JwtService,
+              auth: AuthService,
+              refresh: unknown,
+            ): LoginService => new LoginService(database, jwt, auth, refresh as never),
+            inject: [DatabaseService, JwtService, AuthService, 'RefreshTokenServiceMock'],
+          },
+          { provide: APP_GUARD, useClass: SepThrottlerGuard },
+        ],
+      })
+      class T13TestModule {}
+
+      const moduleRef = await Test.createTestingModule({ imports: [T13TestModule] }).compile();
+      app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+      app.useGlobalPipes(new ZodValidationPipe());
+      app.useGlobalFilters(new HttpExceptionFilter());
+      await app.init();
+      await app.getHttpAdapter().getInstance().ready();
+    }, 30_000);
+
+    afterAll(async () => {
+      await app.close();
+      await seedClient.user.deleteMany({ where: { tenantId: TENANT_ID, email: VICTIM_EMAIL } });
+      await seedClient.$disconnect();
+      await runtimeClient.$disconnect();
+      redis.disconnect();
+      redisAdmin.disconnect();
+    }, 30_000);
+
+    // Reset state between tests so each scenario starts clean. Use
+    // the admin client (no keyPrefix) so DEL operates on the fully-
+    // qualified keys KEYS returns.
+    beforeEach(async () => {
+      await seedClient.user.updateMany({
+        where: { tenantId: TENANT_ID, email: VICTIM_EMAIL },
+        data: { failedLoginAttempts: 0, lockedUntil: null, lastFailedAt: null },
+      });
+      const keys = await redisAdmin.keys(`${prefix}*`);
+      if (keys.length > 0) {
+        await redisAdmin.del(...keys);
+      }
+    });
+
+    function postLogin(
+      email: string,
+      password: string,
+    ): Promise<{
+      statusCode: number;
+      json(): { error?: { code?: string; message?: string } };
+    }> {
+      return app
+        .getHttpAdapter()
+        .getInstance()
+        .inject({
+          method: 'POST',
+          url: '/auth/login',
+          payload: { tenantId: TENANT_ID, email, password },
+        });
+    }
+
+    it('5 wrong-password attempts reach LoginService → counter = 5, no 429, no lockout', async () => {
+      for (let i = 0; i < 5; i += 1) {
+        const res = await postLogin(VICTIM_EMAIL, WRONG_PASSWORD);
+        expect(res.statusCode).toBe(401);
+      }
+      const user = await seedClient.user.findFirst({
+        where: { tenantId: TENANT_ID, email: VICTIM_EMAIL },
+        select: { failedLoginAttempts: true, lockedUntil: true },
+      });
+      expect(user?.failedLoginAttempts).toBe(5);
+      expect(user?.lockedUntil).toBeNull();
+    });
+
+    it('6th wrong-password attempt returns 429 RATE_LIMIT_EXCEEDED — throttler fires BEFORE LoginService', async () => {
+      for (let i = 0; i < 5; i += 1) {
+        await postLogin(VICTIM_EMAIL, WRONG_PASSWORD);
+      }
+      const overflow = await postLogin(VICTIM_EMAIL, WRONG_PASSWORD);
+      expect(overflow.statusCode).toBe(429);
+      const body = overflow.json();
+      expect(body.error?.code).toBe('RATE_LIMIT_EXCEEDED');
+      // Load-bearing: counter stays at 5 because the guard blocked
+      // before LoginService ran. Attacker can't freely ratchet the
+      // lockout counter — throttler caps them at 5 per 15min window.
+      const user = await seedClient.user.findFirst({
+        where: { tenantId: TENANT_ID, email: VICTIM_EMAIL },
+        select: { failedLoginAttempts: true },
+      });
+      expect(user?.failedLoginAttempts).toBe(5);
+    });
+
+    it('after throttler reset, attempts 6-10 reach LoginService and the 10th triggers account lockout', async () => {
+      // Burn 5, then reset the throttler counter (simulates the
+      // attacker waiting out the 15-min window OR moving to a new
+      // IP). Post-reset, 5 more attempts reach LoginService.
+      for (let i = 0; i < 5; i += 1) {
+        await postLogin(VICTIM_EMAIL, WRONG_PASSWORD);
+      }
+      const keysBefore = await redisAdmin.keys(`${prefix}*`);
+      if (keysBefore.length > 0) {
+        await redisAdmin.del(...keysBefore);
+      }
+      for (let i = 0; i < 5; i += 1) {
+        const res = await postLogin(VICTIM_EMAIL, WRONG_PASSWORD);
+        expect(res.statusCode).toBe(401);
+      }
+      const user = await seedClient.user.findFirst({
+        where: { tenantId: TENANT_ID, email: VICTIM_EMAIL },
+        select: { failedLoginAttempts: true, lockedUntil: true },
+      });
+      expect(user?.failedLoginAttempts).toBe(10);
+      expect(user?.lockedUntil).not.toBeNull();
+      expect(user?.lockedUntil?.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('locked account: correct password still returns AUTH_ACCOUNT_LOCKED until lockedUntil passes', async () => {
+      // Pre-lock the user directly so this test doesn't depend on
+      // the prior test's residual state.
+      const lockedUntil = new Date(Date.now() + 30 * 60_000);
+      await seedClient.user.updateMany({
+        where: { tenantId: TENANT_ID, email: VICTIM_EMAIL },
+        data: { failedLoginAttempts: 10, lockedUntil },
+      });
+
+      const res = await postLogin(VICTIM_EMAIL, CORRECT_PASSWORD);
+      expect(res.statusCode).toBe(401);
+      const body = res.json();
+      expect(body.error?.code).toBe('AUTH_ACCOUNT_LOCKED');
+      expect(body.error?.message).toContain('locked until');
+    });
+  },
+);

--- a/apps/control-plane/vitest.config.ts
+++ b/apps/control-plane/vitest.config.ts
@@ -11,7 +11,12 @@ export default defineConfig({
     // config (vitest.integration.config.ts) with env-var gating for real
     // Postgres / Redis. Exclude from the default unit run so `pnpm test`
     // stays offline-safe.
-    exclude: ['**/node_modules/**', '**/dist/**', '**/*.integration.test.ts'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/*.integration.test.ts',
+      '**/*.threat.test.ts',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/apps/control-plane/vitest.integration.config.ts
+++ b/apps/control-plane/vitest.integration.config.ts
@@ -29,7 +29,10 @@ export default defineConfig({
     name: '@sep/control-plane-integration',
     globals: true,
     environment: 'node',
-    include: ['**/*.integration.test.ts'],
+    // M3.A8 adds `*.threat.test.ts` alongside `*.integration.test.ts`
+    // for threat-scenario tests that need to poke at control-plane
+    // internals (guards, services). Same env-gate + infra requirements.
+    include: ['**/*.integration.test.ts', '**/*.threat.test.ts'],
     exclude: ['**/node_modules/**', '**/dist/**'],
     // Integration scenarios spawn concurrent DB writes; forks + no file
     // parallelism keeps connection-pool pressure bounded and matches the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -802,6 +802,9 @@ importers:
 
   tests/threat-scenarios:
     dependencies:
+      '@nest-lab/throttler-storage-redis':
+        specifier: ^1
+        version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2))(ioredis@5.4.1)(reflect-metadata@0.2.2)
       '@nestjs/common':
         specifier: 11.1.18
         version: 11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -817,6 +820,9 @@ importers:
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@nestjs/throttler':
+        specifier: 6.5.0
+        version: 6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
       '@node-rs/argon2':
         specifier: 2.0.2
         version: 2.0.2
@@ -844,6 +850,9 @@ importers:
       jsonwebtoken:
         specifier: 9.0.2
         version: 9.0.2
+      nestjs-zod:
+        specifier: 5.3.0
+        version: 5.3.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/swagger@11.2.7(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2))(rxjs@7.8.2)(zod@3.25.76)
     devDependencies:
       '@types/jsonwebtoken':
         specifier: 9.0.10

--- a/tests/threat-scenarios/package.json
+++ b/tests/threat-scenarios/package.json
@@ -9,11 +9,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@nest-lab/throttler-storage-redis": "^1",
     "@nestjs/common": "11.1.18",
     "@nestjs/core": "11.1.18",
     "@nestjs/jwt": "11.0.2",
     "@nestjs/platform-fastify": "11.1.18",
     "@nestjs/testing": "^11.1.18",
+    "@nestjs/throttler": "6.5.0",
     "@node-rs/argon2": "2.0.2",
     "@prisma/client": "5.22.0",
     "@sep/common": "workspace:*",
@@ -22,7 +24,8 @@
     "@sep/schemas": "workspace:*",
     "@sep/simulators": "workspace:*",
     "ioredis": "5.4.1",
-    "jsonwebtoken": "9.0.2"
+    "jsonwebtoken": "9.0.2",
+    "nestjs-zod": "5.3.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "9.0.10",


### PR DESCRIPTION
## Summary

M3.A8 PR 2 of 5 — auth-class threat scenarios. Ships 3 scenarios + 1 bug fix caught by scenario coverage.

## Scenarios shipped

| # | File | Asserts |
|---|------|---------|
| T1 | `apps/control-plane/src/modules/auth/T01_stolen_credential.threat.test.ts` | MFA-enrolled user + correct password → only an MFA challenge token (no accessToken/refreshToken). Decoded challenge JWT carries `typ: 'mfa_challenge'`. |
| T12 | `apps/control-plane/src/modules/auth/T12_refresh_token_replay.threat.test.ts` | Replaying a used refresh token (after A→B→C rotation) → `AUTH_REFRESH_TOKEN_REPLAY`, whole chain revoked with `reason='replay-detected'`. Rotating C afterwards → `AUTH_REFRESH_TOKEN_INVALID`. |
| T13 | `apps/control-plane/src/modules/auth/T13_brute_force.threat.test.ts` | Throttler (5/15min per IP+email) fires at 6th attempt BEFORE LoginService runs → failedLoginAttempts stays at 5. After throttler reset, 5 more attempts reach LoginService → 10th sets `lockedUntil`. Locked account + correct password → `AUTH_ACCOUNT_LOCKED`. |

## Bug caught by T13

**`HttpExceptionFilter` code hoisting** (pre-existing since M3.A4). LoginService throws `new UnauthorizedException(sepError.toClientJson())` — the filter extracted `message` but NOT `code`/`retryable`/`terminal`, so clients saw `code: 'INTERNAL_ERROR'` with the right message. T13's "locked account" test caught this because it's the first test that asserts `body.error.code === 'AUTH_ACCOUNT_LOCKED'` through the HTTP layer. **Fix:** ~15 lines in the filter to hoist the SepError contract fields when present. Existing paths unchanged.

Fixed in-PR per the small-bug policy you set at PR 1.

## Layout adjustment

Original plan said `tests/threat-scenarios/T<NN>_<name>.threat.test.ts`. Any scenario that imports control-plane internals (guards, services, filters) hits tsconfig rootDir errors across the workspace boundary (same constraint I hit in M3.A4-T06). Resolution:

- **In-package `.threat.test.ts`** for scenarios that need app internals. Picked up by `vitest.integration.config.ts`'s `**/*.threat.test.ts` include (widened from `.integration.test.ts` only). `vitest.config.ts`'s unit-run exclude also widened.
- **`tests/threat-scenarios/` stays as the coordination hub** — scenario-ID registry, tenant cuid registry, clients/redis helpers, smoke test. Future operational-class scenarios (T2, T7, T10) can live here since they poke at boundaries, not internals.

Tenant cuids in `tests/threat-scenarios/_helpers/tenants.ts` match the inlined constants in each in-package scenario file so a developer following the registry back has a cross-reference.

## Schedule

| PR | Scenarios | Host |
|---|---|---|
| 1 ✅ | scaffolding | |
| 2 this | T1, T12, T13 | apps/control-plane |
| 3 | T5, T8, T9, T14 | apps/control-plane + tests/threat-scenarios |
| 4 | T3, T4, T6, T11 | packages/crypto + apps/control-plane |
| 5 | T2, T7, T10 | tests/threat-scenarios + M3.A8 close-out |

## Tests

| Suite | Before | After |
|---|---|---|
| `@sep/control-plane` unit | 181 | 181 (no change) |
| `@sep/control-plane` integration | 9 | 17 (+8 — T1 × 2, T12 × 2, T13 × 4) |

## Test plan

- [x] Unit: 181/181 green
- [x] Integration: 17/17 green with Postgres + Redis
- [x] Typecheck + lint clean
- [ ] CI green on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)