### PR TITLE
test(m3.a8): DB-layer threat scenarios T14 audit immutability + T5 idempotency uniqueness (PR 3/6)

### DIFF
--- a/tests/threat-scenarios/T05_idempotency_replay.threat.test.ts
+++ b/tests/threat-scenarios/T05_idempotency_replay.threat.test.ts
@@ -1,0 +1,187 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
+
+/**
+ * Threat scenario T5 — Replayed submission / idempotency key replay (M3.A8).
+ *
+ * Plan §6 scenario ID: T5. Primary control:
+ * `@@unique([tenantId, idempotencyKey])` enforcement on
+ * submissions.
+ *
+ * Attack model:
+ *   1. Legitimate client submits payload P with idempotency key K.
+ *   2. Attacker captures K (from a log line / proxy /
+ *      retry-observer).
+ *   3. Attacker submits a different payload P' with the same K,
+ *      hoping the server treats it as the same submission (if
+ *      dedup is lax) or as a fresh one that bypasses quotas /
+ *      delivery (if the unique constraint is missing).
+ *
+ * Defense mechanism (two layers):
+ *   - DB layer: Prisma @@unique([tenantId, idempotencyKey])
+ *     enforces a per-tenant unique index. Direct INSERT of a
+ *     second row with the same (tenantId, idempotencyKey) pair
+ *     fails with Postgres error 23505 (unique_violation).
+ *   - Service layer: SubmissionsService.create explicitly queries
+ *     by the (tenantId, idempotencyKey) tuple BEFORE the INSERT
+ *     and throws SepError(VALIDATION_DUPLICATE) with the existing
+ *     submission's id in context. T5 tests the DB layer directly
+ *     (no service boot needed); the service-layer path is covered
+ *     by the existing submissions.service.test.ts unit test.
+ *
+ * Cross-tenant note: the unique is (tenantId, idempotencyKey), not
+ * idempotencyKey alone. Two different tenants CAN use the same key
+ * legitimately — each tenant's key space is scoped. This test
+ * includes a positive case asserting that cross-tenant uniqueness
+ * isn't enforced, which is the intended behaviour.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'crypto';
+import { Prisma, type PrismaClient } from '@prisma/client';
+import { hasPostgres, makeSeedClient } from './_helpers/clients';
+import { TENANTS, ensureThreatTestTenants } from './_helpers/tenants';
+import { scenarioTitle } from './_helpers/scenario-id';
+
+const TENANT_ID = TENANTS.T05_idempotency_owner;
+const OTHER_TENANT_ID = TENANTS.T08_cross_tenant_victim; // any other seeded tenant works
+
+describe.skipIf(!hasPostgres)(
+  scenarioTitle(
+    'T5',
+    'same (tenantId, idempotencyKey) rejected as duplicate; cross-tenant unaffected',
+  ),
+  () => {
+    let seedClient: PrismaClient;
+    let partnerProfileId: string;
+
+    beforeAll(async () => {
+      seedClient = makeSeedClient();
+      await ensureThreatTestTenants(seedClient, [
+        'T05_idempotency_owner',
+        'T08_cross_tenant_victim',
+      ]);
+
+      // Submissions require a partner profile FK. Create one (idempotent).
+      const existingProfile = await seedClient.partnerProfile.findFirst({
+        where: { tenantId: TENANT_ID, name: 'T5 Test Partner Profile' },
+      });
+      if (existingProfile === null) {
+        const profile = await seedClient.partnerProfile.create({
+          data: {
+            tenantId: TENANT_ID,
+            name: 'T5 Test Partner Profile',
+            partnerType: 'BANK',
+            environment: 'TEST',
+            transportProtocol: 'SFTP',
+            messageSecurityMode: 'SIGN_ENCRYPT',
+            config: {
+              sftp: {
+                host: 'sftp.t5.example',
+                port: 22,
+                username: 'sep-t5',
+                hostKeyFingerprint: 'SHA256:t5-placeholder',
+                uploadPath: '/in',
+                downloadPath: '/out',
+              },
+            },
+          },
+        });
+        partnerProfileId = profile.id;
+      } else {
+        partnerProfileId = existingProfile.id;
+      }
+    }, 30_000);
+
+    afterAll(async () => {
+      await seedClient.submission.deleteMany({ where: { tenantId: TENANT_ID } });
+      await seedClient.submission.deleteMany({ where: { tenantId: OTHER_TENANT_ID } });
+      await seedClient.$disconnect();
+    });
+
+    it('second INSERT with same (tenantId, idempotencyKey) fails with Postgres 23505 unique_violation', async () => {
+      const idempotencyKey = `t5-replay-${randomUUID()}`;
+      const base = {
+        tenantId: TENANT_ID,
+        partnerProfileId,
+        idempotencyKey,
+        contentType: 'application/json',
+        payloadRef: 'payload-ref-1',
+      };
+
+      // First INSERT succeeds.
+      const first = await seedClient.submission.create({ data: base });
+      expect(first.id).toBeTruthy();
+
+      // Second INSERT with THE SAME key is rejected. Prisma maps
+      // Postgres 23505 to PrismaClientKnownRequestError with code
+      // P2002 (unique constraint failed).
+      try {
+        await seedClient.submission.create({
+          data: { ...base, payloadRef: 'payload-ref-2' },
+        });
+        throw new Error('expected P2002 but create succeeded');
+      } catch (err) {
+        expect(err).toBeInstanceOf(Prisma.PrismaClientKnownRequestError);
+        expect((err as Prisma.PrismaClientKnownRequestError).code).toBe('P2002');
+        // Target must name both tenantId and idempotencyKey — guards
+        // against a future schema change that drops tenantId from the
+        // unique.
+        const target = (err as Prisma.PrismaClientKnownRequestError).meta?.['target'];
+        const targetStr = Array.isArray(target) ? target.join(',') : String(target);
+        expect(targetStr).toContain('tenantId');
+        expect(targetStr).toContain('idempotencyKey');
+      }
+    });
+
+    it('different tenant using the same idempotencyKey is permitted (per-tenant scope)', async () => {
+      // Need a partner profile in the other tenant too.
+      const otherProfile = await seedClient.partnerProfile.create({
+        data: {
+          tenantId: OTHER_TENANT_ID,
+          name: 'T5 Cross-Tenant Partner Profile',
+          partnerType: 'BANK',
+          environment: 'TEST',
+          transportProtocol: 'SFTP',
+          messageSecurityMode: 'SIGN_ENCRYPT',
+          config: {
+            sftp: {
+              host: 'sftp.t5-other.example',
+              port: 22,
+              username: 'sep-t5-other',
+              hostKeyFingerprint: 'SHA256:t5-other-placeholder',
+              uploadPath: '/in',
+              downloadPath: '/out',
+            },
+          },
+        },
+      });
+      try {
+        const sharedKey = `t5-cross-${randomUUID()}`;
+        const a = await seedClient.submission.create({
+          data: {
+            tenantId: TENANT_ID,
+            partnerProfileId,
+            idempotencyKey: sharedKey,
+            contentType: 'application/json',
+            payloadRef: 'payload-ref-a',
+          },
+        });
+        const b = await seedClient.submission.create({
+          data: {
+            tenantId: OTHER_TENANT_ID,
+            partnerProfileId: otherProfile.id,
+            idempotencyKey: sharedKey,
+            contentType: 'application/json',
+            payloadRef: 'payload-ref-b',
+          },
+        });
+        expect(a.id).not.toBe(b.id);
+        expect(a.tenantId).not.toBe(b.tenantId);
+        expect(a.idempotencyKey).toBe(b.idempotencyKey);
+      } finally {
+        await seedClient.submission.deleteMany({ where: { partnerProfileId: otherProfile.id } });
+        await seedClient.partnerProfile.delete({ where: { id: otherProfile.id } });
+      }
+    });
+  },
+);

--- a/tests/threat-scenarios/T14_audit_chain_tampering.threat.test.ts
+++ b/tests/threat-scenarios/T14_audit_chain_tampering.threat.test.ts
@@ -1,0 +1,287 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, no-await-in-loop */
+
+/**
+ * Threat scenario T14 — Audit chain tampering (M3.A8).
+ *
+ * Plan §6 scenario ID: T14. Primary control: REVOKE + RLS + hash-
+ * chain verification.
+ *
+ * Three attack variants are exercised:
+ *   1. UPDATE audit_events → blocked by `audit_events_no_update`
+ *      trigger (defense-in-depth over the per-role REVOKE). The
+ *      trigger RAISEs with SQLSTATE 42501 (insufficient_privilege).
+ *   2. DELETE audit_events → blocked by `audit_events_no_delete`
+ *      trigger, same mechanism.
+ *   3. Forged INSERT with a broken previousHash — the DB triggers
+ *      don't block arbitrary INSERTs (INSERT is the legitimate
+ *      append path), so tamper detection happens at verification
+ *      time. A hash-chain verifier re-derives each event's
+ *      immutableHash from its predecessor and the hashSecret; a
+ *      forged row shows up as a mismatch on its SUCCESSOR (the
+ *      forgery's immutableHash != the next row's previousHash).
+ *
+ * No app internals needed — this scenario lives in
+ * tests/threat-scenarios/ and exercises only the DB layer + the
+ * @sep/common hashSecret config. The AuditService's hash algorithm
+ * is re-implemented inline so the test is self-contained: future
+ * changes to that algorithm would need to update both places,
+ * which is the right signal (a future change that only touches one
+ * would silently break the chain).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { createHash } from 'crypto';
+import { hasPostgres, makeSeedClient, makeRuntimeClient } from './_helpers/clients';
+import { TENANTS, ensureThreatTestTenants } from './_helpers/tenants';
+import { scenarioTitle } from './_helpers/scenario-id';
+import type { PrismaClient, AuditAction } from '@prisma/client';
+
+const TENANT_ID = TENANTS.T14_audit_tamper_owner;
+const HASH_SECRET = 'threat-scenario-test-audit-hash-secret-min32ch';
+
+/**
+ * Re-implements AuditService.record's hash derivation so the test
+ * can seed a real chain without depending on the control-plane's
+ * NestJS service boot. Inputs match AuditService exactly:
+ *   sha256(tenantId|actorId|action|result|eventTime.toISOString()|
+ *          previousHash or 'genesis'|hashSecret)
+ */
+function computeHash(input: {
+  tenantId: string;
+  actorId: string;
+  action: string;
+  result: string;
+  eventTime: Date;
+  previousHash: string | null;
+}): string {
+  const parts = [
+    input.tenantId,
+    input.actorId,
+    input.action,
+    input.result,
+    input.eventTime.toISOString(),
+    input.previousHash ?? 'genesis',
+    HASH_SECRET,
+  ];
+  return createHash('sha256').update(parts.join('|')).digest('hex');
+}
+
+interface AuditEventRow {
+  id: string;
+  tenantId: string;
+  actorId: string;
+  action: string;
+  result: string;
+  eventTime: Date;
+  immutableHash: string;
+  previousHash: string | null;
+}
+
+/**
+ * Independent chain verifier. Walks events in eventTime order and
+ * re-derives each row's immutableHash from the previous row +
+ * hashSecret. Returns the first index where the derived hash
+ * mismatches the stored hash, or -1 if the chain is intact.
+ *
+ * A successful forgery would need to rewrite every successor's
+ * immutableHash too — but those rows are also protected by the
+ * trigger, so the attacker cannot do so without privileged role
+ * + a schema-level migration.
+ */
+function verifyChain(events: readonly AuditEventRow[]): number {
+  for (let i = 0; i < events.length; i += 1) {
+    const evt = events[i];
+    if (evt === undefined) {
+      continue;
+    }
+    const expectedPrev = i === 0 ? null : (events[i - 1]?.immutableHash ?? null);
+    if (evt.previousHash !== expectedPrev) {
+      return i;
+    }
+    const derived = computeHash({
+      tenantId: evt.tenantId,
+      actorId: evt.actorId,
+      action: evt.action,
+      result: evt.result,
+      eventTime: evt.eventTime,
+      previousHash: evt.previousHash,
+    });
+    if (evt.immutableHash !== derived) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+describe.skipIf(!hasPostgres)(
+  scenarioTitle(
+    'T14',
+    'audit chain tampering: UPDATE/DELETE blocked by trigger; forged INSERT caught by hash-chain verifier',
+  ),
+  () => {
+    let seedClient: PrismaClient;
+    let runtimeClient: PrismaClient;
+    const actorId = 'ct14audittamperingactor01';
+
+    beforeAll(async () => {
+      seedClient = makeSeedClient();
+      runtimeClient = makeRuntimeClient();
+      await ensureThreatTestTenants(seedClient, ['T14_audit_tamper_owner']);
+    }, 30_000);
+
+    afterAll(async () => {
+      // Can't DELETE — the append-only trigger blocks it regardless
+      // of role. TRUNCATE bypasses triggers by schema privilege; the
+      // sep migration role owns the table and is allowed to TRUNCATE.
+      await seedClient.$executeRawUnsafe(`TRUNCATE TABLE audit_events RESTART IDENTITY CASCADE`);
+      await seedClient.$disconnect();
+      await runtimeClient.$disconnect();
+    });
+
+    beforeEach(async () => {
+      // Clean slate: seedClient has BYPASSRLS so this works even
+      // though the runtime role can't.
+      // NB: we cannot use DELETE to clean up — the trigger forbids
+      // DELETE regardless of role. Use raw TRUNCATE as a privileged
+      // sep-role escape hatch.
+      await seedClient.$executeRawUnsafe(`TRUNCATE TABLE audit_events RESTART IDENTITY CASCADE`);
+    });
+
+    async function seedEvent(
+      actorSuffix: string,
+      action: AuditAction,
+      previousHash: string | null,
+    ): Promise<AuditEventRow> {
+      const eventTime = new Date();
+      // Small stagger so eventTime ordering is deterministic across
+      // successive seeds within one test.
+      await new Promise((r) => setTimeout(r, 2));
+      const immutableHash = computeHash({
+        tenantId: TENANT_ID,
+        actorId: `${actorId}-${actorSuffix}`,
+        action,
+        result: 'SUCCESS',
+        eventTime,
+        previousHash,
+      });
+      const row = await seedClient.auditEvent.create({
+        data: {
+          tenantId: TENANT_ID,
+          actorType: 'USER',
+          actorId: `${actorId}-${actorSuffix}`,
+          actorRole: 'TENANT_ADMIN',
+          objectType: 'Tenant',
+          objectId: TENANT_ID,
+          action,
+          result: 'SUCCESS',
+          eventTime,
+          immutableHash,
+          previousHash,
+        },
+      });
+      return {
+        id: row.id,
+        tenantId: row.tenantId,
+        actorId: row.actorId,
+        action: String(row.action),
+        result: row.result,
+        eventTime: row.eventTime,
+        immutableHash: row.immutableHash,
+        previousHash: row.previousHash,
+      };
+    }
+
+    it('UPDATE against audit_events is rejected by the append-only trigger', async () => {
+      const genesis = await seedEvent('genesis', 'TENANT_CREATED', null);
+
+      // Attempt UPDATE via the sep role (has BYPASSRLS) — the trigger
+      // should fire anyway. Postgres triggers are NOT scoped by role;
+      // they run for every statement that touches the table.
+      await expect(
+        seedClient.$executeRawUnsafe(
+          `UPDATE audit_events SET "actorId" = 'hacker' WHERE id = $1`,
+          genesis.id,
+        ),
+      ).rejects.toThrow(/append-only|insufficient_privilege/i);
+    });
+
+    it('DELETE against audit_events is rejected by the append-only trigger', async () => {
+      const genesis = await seedEvent('genesis', 'TENANT_CREATED', null);
+      await expect(
+        seedClient.$executeRawUnsafe(`DELETE FROM audit_events WHERE id = $1`, genesis.id),
+      ).rejects.toThrow(/append-only|insufficient_privilege/i);
+    });
+
+    it('forged INSERT with arbitrary immutableHash is INSERT-permitted but caught by chain verification', async () => {
+      // Build a legitimate chain of 3 events.
+      const e1 = await seedEvent('u1', 'TENANT_CREATED', null);
+      const e2 = await seedEvent('u2', 'USER_CREATED', e1.immutableHash);
+      const e3 = await seedEvent('u3', 'USER_CREATED', e2.immutableHash);
+
+      // Verify the untampered chain passes.
+      expect(verifyChain([e1, e2, e3])).toBe(-1);
+
+      // Attacker INSERTs a forged event between e2 and e3, claiming
+      // to chain off e2 but using an attacker-chosen hash. The DB
+      // accepts the row (INSERT isn't blocked) — the tamper is only
+      // visible at verification time because the NEXT event (e3)
+      // still points at e2's real hash, not the forgery's.
+      const forgedEventTime = new Date(e2.eventTime.getTime() + 1);
+      const forgeryImmutableHash = 'f'.repeat(64); // attacker-chosen
+      await seedClient.auditEvent.create({
+        data: {
+          tenantId: TENANT_ID,
+          actorType: 'USER',
+          actorId: `${actorId}-forger`,
+          actorRole: 'TENANT_ADMIN',
+          objectType: 'Tenant',
+          objectId: TENANT_ID,
+          action: 'USER_CREATED',
+          result: 'SUCCESS',
+          eventTime: forgedEventTime,
+          immutableHash: forgeryImmutableHash,
+          previousHash: e2.immutableHash,
+        },
+      });
+
+      // Re-read in chain order.
+      const rows = await seedClient.auditEvent.findMany({
+        where: { tenantId: TENANT_ID },
+        orderBy: { eventTime: 'asc' },
+        select: {
+          id: true,
+          tenantId: true,
+          actorId: true,
+          action: true,
+          result: true,
+          eventTime: true,
+          immutableHash: true,
+          previousHash: true,
+        },
+      });
+      expect(rows).toHaveLength(4);
+
+      // The verifier walks the ordered events and returns the
+      // first index where the derived hash mismatches the stored
+      // hash. The forgery lives at index 2 (between e2 and e3); the
+      // verifier catches it because `f...` != sha256(inputs +
+      // hashSecret).
+      const firstBadIndex = verifyChain(rows as unknown as readonly AuditEventRow[]);
+      expect(firstBadIndex).toBe(2);
+    });
+
+    it('attempted UPDATE via runtime role (sep_app) also rejected', async () => {
+      const genesis = await seedEvent('genesis', 'TENANT_CREATED', null);
+      // runtimeClient connects as sep_app which has RLS enforced
+      // AND lacks UPDATE grant on audit_events. Attempting this
+      // combination hits the trigger (defense-in-depth) before
+      // Postgres even reaches the RLS check.
+      await expect(
+        runtimeClient.$executeRawUnsafe(
+          `UPDATE audit_events SET "actorId" = 'hacker' WHERE id = $1`,
+          genesis.id,
+        ),
+      ).rejects.toThrow(/append-only|insufficient_privilege|permission denied/i);
+    });
+  },
+);


### PR DESCRIPTION
## Summary

M3.A8 PR 3 of 6 — DB-layer threat scenarios. Ships **T14** (audit chain tampering) + **T5** (idempotency replay). Neither is strictly RLS: T14 exercises the `audit_events` append-only triggers + hash-chain verification, and T5 exercises the `@@unique([tenantId, idempotencyKey])` on submissions.

**Scope reduction vs. original schedule.** PR 1's landing plan grouped T5 + T8 + T9 + T14 on PR 3. T8 (cross-tenant BOLA) and T9 (RBAC on partner-profile change) are auth-HTTP-class scenarios that need full `AppModule` boot — a materially different test scaffold than what T14/T5 use (both hit the DB directly via raw Prisma + `sep`/`sep_app` roles). Splitting PR 3 around that scaffolding boundary keeps the reviewable surface small and moves T8/T9 to a fresh session with its own scaffolding story.

## Scenarios shipped

| # | File | Asserts |
|---|---|---|
| T14 | `tests/threat-scenarios/T14_audit_chain_tampering.threat.test.ts` | 4 cases: UPDATE blocked by `audit_events_no_update` trigger (via `sep` role, BYPASSRLS); DELETE blocked by `audit_events_no_delete` trigger; forged INSERT permitted at the DB but caught by an independent hash-chain verifier at the exact tampered index; UPDATE via `sep_app` runtime role also blocked (defense-in-depth). |
| T5 | `tests/threat-scenarios/T05_idempotency_replay.threat.test.ts` | 2 cases: second INSERT with same `(tenantId, idempotencyKey)` → Prisma `P2002` with target containing **both** `tenantId` and `idempotencyKey`; cross-tenant positive — two different tenants CAN share the same key (per-tenant scoping intended). |

## What the tests prove

**T14 — audit immutability (two defense layers).** The `audit_events_no_update` and `audit_events_no_delete` triggers fire for every statement regardless of role (triggers are not role-scoped in Postgres). T14 proves this against both `sep` (migration role, BYPASSRLS) and `sep_app` (runtime role, RLS forced). The forged-INSERT path confirms INSERT is the legitimate append path and tamper detection lives at read time: an independent hash-chain verifier re-derives each row's `immutableHash` from `tenantId|actorId|action|result|eventTime|previousHash||hashSecret` and compares to stored. A forgery at position `i` surfaces because (a) position `i`'s derived hash ≠ stored hash, and (b) position `i+1`'s `previousHash` still points at the real `i`-th hash. An attacker would need to tamper every successor, which the trigger blocks.

**T5 — idempotency uniqueness with per-tenant scope.** The unique target must include **both** `tenantId` and `idempotencyKey`. A future schema migration that accidentally drops `tenantId` from the unique (e.g., consolidating to a global idempotency keyspace) would break the cross-tenant positive test immediately and the `P2002` target assertion in the negative test — two independent tripwires. The service-layer `VALIDATION_DUPLICATE` branch is not re-tested here (covered by existing `submissions.service.test.ts` unit tests from prior milestones); T5 focuses on the DB-layer constraint as last line of defense.

## Self-review (§10.1 — light scrutiny)

Per `_plan/M3_EXECUTION_PLAN.md` §10.1 option (ii), substantive scrutiny is required for PRs touching the three binding paths: `packages/db/prisma/migrations/`, `packages/crypto/`, `apps/control-plane/src/modules/auth/`.

**This PR touches none of the three.** The diff is additive test-only under `tests/threat-scenarios/` — it exercises the audit trigger + unique index that already exist in shipped migrations, without modifying them. Light scrutiny is proportionate.

- **Threat model.** T14 and T5 each carry a documented attack model in their file headers (captured hash → replay, forged row) and the test body asserts the invariant that defeats it.
- **No bugs surfaced.** Both scenarios passed on first green. Invariants (trigger rejection, `P2002` target shape, per-tenant unique scope) were already wired correctly from earlier migrations. No inline fixes in this PR — and per the plan, not pre-fixing speculatively: T8/T9 are where the next bugs are most likely to surface.
- **Algorithm duplication is deliberate.** T14's inline `computeHash` re-implements `AuditService.record`'s hash derivation rather than importing across the workspace boundary (`apps/control-plane` → `tests/threat-scenarios`). A one-sided future change to either breaks the verifier — intended tripwire, documented in the file header.
- **Rollback.** Pure test additions, no runtime change. Revert = delete two files. No migration, no schema change, no service touch.
- **Fresh-eyes re-read.** Walked both files post-commit: tenant cuids match the `_helpers/tenants.ts` registry; T14's `afterAll`/`beforeEach` use raw `TRUNCATE` (DELETE is trigger-blocked regardless of role); T5's cross-tenant case cleans up its ad-hoc partner profile via `finally` regardless of assertion outcome.

## Tests

| Suite | Before | After | Delta |
|---|---|---|---|
| `@sep/threat-scenarios` | 3 | 9 | +6 (T14 × 4, T5 × 2) |
| `@sep/control-plane` unit | 181 | 181 | — |
| `@sep/control-plane` integration | 17 | 17 | — |

## Revised M3.A8 schedule

| PR | Scenarios | Host | Status |
|---|---|---|---|
| 1 ✅ | scaffolding | — | merged #44 |
| 2 ✅ | T1, T12, T13 | apps/control-plane | merged #45 |
| 3 (this) | T14, T5 | tests/threat-scenarios | in review |
| 4 | T8, T9 | apps/control-plane (new: AppModule boot) | fresh session |
| 5 | T3, T4, T6, T11 | packages/crypto + apps/control-plane | fresh session |
| 6 | T2, T7, T10 | tests/threat-scenarios + M3.A8 close-out | fresh session |

PR 3 → 6 split (from original 5-PR plan) is a context-length decision, not workload. The next scaffolding jump — `AppModule`-booted HTTP scenarios for T8/T9 — is a new pattern beyond M3.A1-T06's rls-negative-tests and warrants a fresh session.

## Test plan

- [x] `pnpm --filter @sep/threat-scenarios test:integration` — 9/9 green
- [x] Typecheck clean
- [x] Lint clean
- [ ] CI green on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)